### PR TITLE
feat: add reproducible benchmark framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,10 @@ desktop.ini
 
 # Logs
 *.log
+
+# Benchmark input videos and generated results
+benchmarks/data/*
+!benchmarks/data/README.md
+
+benchmarks/results/*
+!benchmarks/results/.gitkeep

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,100 @@
+# VisionLab Benchmark Reproducibility Guide
+
+Follow this guide from the repository root (`VisionLab/`) to reproduce the benchmark results across all three implementations.
+
+## 1) Prepare input video
+
+Place the benchmark video at:
+
+```text
+benchmarks/data/benchmark_input.mp4
+```
+
+Detailed input requirements are documented in `benchmarks/data/README.md`.
+
+## 2) Install dependencies
+
+### Pure Python runner
+
+```bash
+cd pure-python
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+cd ..
+```
+
+### Hybrid Python+C++ runner
+
+```bash
+cd hybrid-python-cpp
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+cd ..
+```
+
+### C++ benchmark executable
+
+Install system dependencies required by CMake for:
+
+- C++17 compiler toolchain
+- OpenCV development package
+- Qt6 Core/Gui/Widgets/OpenGLWidgets
+
+## 3) Build Release binaries
+
+### Hybrid module (Release)
+
+```bash
+cmake -S hybrid-python-cpp -B hybrid-python-cpp/build -DCMAKE_BUILD_TYPE=Release
+cmake --build hybrid-python-cpp/build --config Release
+```
+
+### Pure C++ benchmark executable (Release)
+
+```bash
+cmake -S cpp-opencv-core -B cpp-opencv-core/build -DCMAKE_BUILD_TYPE=Release
+cmake --build cpp-opencv-core/build --config Release --target VisionLabCppBenchmark
+```
+
+## 4) Run benchmark runners
+
+From repository root:
+
+```bash
+python benchmarks/runners/pure_python_benchmark.py
+python benchmarks/runners/hybrid_benchmark.py
+```
+
+Run pure C++ benchmark:
+
+```bash
+./cpp-opencv-core/build/VisionLabCppBenchmark
+# or (multi-config generators)
+./cpp-opencv-core/build/Release/VisionLabCppBenchmark
+```
+
+If your generator places the hybrid module in a non-default location, set:
+
+```bash
+export VISIONLAB_CPP_MODULE_DIR=/absolute/path/to/hybrid-python-cpp/build[/Release]
+```
+
+## 5) Run analysis
+
+```bash
+python benchmarks/analysis/analyze_results.py
+```
+
+## 6) Expected output files
+
+After a successful run, `benchmarks/results/` must contain:
+
+- `pure_python_results.csv`
+- `hybrid_results.csv`
+- `pure_cpp_results.csv`
+- `benchmark_trial_summary.csv`
+- `benchmark_summary.csv`

--- a/benchmarks/analysis/analyze_results.py
+++ b/benchmarks/analysis/analyze_results.py
@@ -1,0 +1,322 @@
+import csv
+import math
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import fmean, median, pstdev
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+RESULTS_DIRECTORY = PROJECT_ROOT / "benchmarks" / "results"
+
+RESULT_FILES = [
+    "pure_python_results.csv",
+    "hybrid_results.csv",
+    "pure_cpp_results.csv",
+]
+
+
+@dataclass(frozen=True)
+class Measurement:
+    architecture: str
+    algorithm: str
+    resolution: str
+    trial: int
+    processing_time_ms: float
+
+
+def calculate_percentile(
+    values: list[float],
+    fraction: float,
+) -> float:
+    ordered_values = sorted(values)
+
+    if len(ordered_values) == 1:
+        return ordered_values[0]
+
+    position = (len(ordered_values) - 1) * fraction
+    lower_index = math.floor(position)
+    upper_index = math.ceil(position)
+
+    if lower_index == upper_index:
+        return ordered_values[lower_index]
+
+    lower_value = ordered_values[lower_index]
+    upper_value = ordered_values[upper_index]
+    weight = position - lower_index
+
+    return lower_value + (
+        upper_value - lower_value
+    ) * weight
+
+
+def calculate_statistics(
+    values: list[float],
+) -> dict[str, float]:
+    mean_ms = fmean(values)
+
+    return {
+        "mean_ms": mean_ms,
+        "median_ms": median(values),
+        "min_ms": min(values),
+        "max_ms": max(values),
+        "std_ms": pstdev(values),
+        "p95_ms": calculate_percentile(
+            values,
+            0.95,
+        ),
+        "effective_fps": (
+            1000.0 / mean_ms
+            if mean_ms > 0.0
+            else 0.0
+        ),
+    }
+
+
+def load_measurements() -> list[Measurement]:
+    measurements = []
+
+    required_fields = {
+        "architecture",
+        "algorithm",
+        "resolution",
+        "trial",
+        "frame_index",
+        "processing_time_ms",
+    }
+
+    for file_name in RESULT_FILES:
+        result_path = RESULTS_DIRECTORY / file_name
+
+        if not result_path.is_file():
+            print(
+                f"Warning: result file not found: "
+                f"{result_path}"
+            )
+            continue
+
+        with result_path.open(
+            "r",
+            newline="",
+            encoding="utf-8",
+        ) as result_file:
+            reader = csv.DictReader(result_file)
+
+            if reader.fieldnames is None:
+                raise ValueError(
+                    f"CSV header missing: {result_path}"
+                )
+
+            missing_fields = (
+                required_fields - set(reader.fieldnames)
+            )
+
+            if missing_fields:
+                raise ValueError(
+                    f"Missing CSV fields in {result_path}: "
+                    f"{sorted(missing_fields)}"
+                )
+
+            for row in reader:
+                processing_time_ms = float(
+                    row["processing_time_ms"]
+                )
+
+                if (
+                    not math.isfinite(processing_time_ms)
+                    or processing_time_ms < 0.0
+                ):
+                    raise ValueError(
+                        "Invalid processing time in "
+                        f"{result_path}: "
+                        f"{processing_time_ms}"
+                    )
+
+                measurements.append(
+                    Measurement(
+                        architecture=row["architecture"],
+                        algorithm=row["algorithm"],
+                        resolution=row["resolution"],
+                        trial=int(row["trial"]),
+                        processing_time_ms=(
+                            processing_time_ms
+                        ),
+                    )
+                )
+
+    if not measurements:
+        raise FileNotFoundError(
+            "No benchmark result files were found."
+        )
+
+    return measurements
+
+
+def write_trial_summary(
+    measurements: list[Measurement],
+) -> Path:
+    groups = defaultdict(list)
+
+    for measurement in measurements:
+        key = (
+            measurement.architecture,
+            measurement.algorithm,
+            measurement.resolution,
+            measurement.trial,
+        )
+
+        groups[key].append(
+            measurement.processing_time_ms
+        )
+
+    output_path = (
+        RESULTS_DIRECTORY
+        / "benchmark_trial_summary.csv"
+    )
+
+    fieldnames = [
+        "architecture",
+        "algorithm",
+        "resolution",
+        "trial",
+        "frame_count",
+        "mean_ms",
+        "median_ms",
+        "min_ms",
+        "max_ms",
+        "std_ms",
+        "p95_ms",
+        "effective_fps",
+    ]
+
+    with output_path.open(
+        "w",
+        newline="",
+        encoding="utf-8",
+    ) as output_file:
+        writer = csv.DictWriter(
+            output_file,
+            fieldnames=fieldnames,
+        )
+        writer.writeheader()
+
+        for key in sorted(groups):
+            architecture, algorithm, resolution, trial = key
+            values = groups[key]
+            statistics = calculate_statistics(values)
+
+            writer.writerow(
+                {
+                    "architecture": architecture,
+                    "algorithm": algorithm,
+                    "resolution": resolution,
+                    "trial": trial,
+                    "frame_count": len(values),
+                    **{
+                        name: f"{value:.6f}"
+                        for name, value
+                        in statistics.items()
+                    },
+                }
+            )
+
+    return output_path
+
+
+def write_overall_summary(
+    measurements: list[Measurement],
+) -> Path:
+    groups = defaultdict(list)
+    trial_numbers = defaultdict(set)
+
+    for measurement in measurements:
+        key = (
+            measurement.architecture,
+            measurement.algorithm,
+            measurement.resolution,
+        )
+
+        groups[key].append(
+            measurement.processing_time_ms
+        )
+        trial_numbers[key].add(
+            measurement.trial
+        )
+
+    output_path = (
+        RESULTS_DIRECTORY
+        / "benchmark_summary.csv"
+    )
+
+    fieldnames = [
+        "architecture",
+        "algorithm",
+        "resolution",
+        "trial_count",
+        "frame_count",
+        "mean_ms",
+        "median_ms",
+        "min_ms",
+        "max_ms",
+        "std_ms",
+        "p95_ms",
+        "effective_fps",
+    ]
+
+    with output_path.open(
+        "w",
+        newline="",
+        encoding="utf-8",
+    ) as output_file:
+        writer = csv.DictWriter(
+            output_file,
+            fieldnames=fieldnames,
+        )
+        writer.writeheader()
+
+        for key in sorted(groups):
+            architecture, algorithm, resolution = key
+            values = groups[key]
+            statistics = calculate_statistics(values)
+
+            writer.writerow(
+                {
+                    "architecture": architecture,
+                    "algorithm": algorithm,
+                    "resolution": resolution,
+                    "trial_count": len(
+                        trial_numbers[key]
+                    ),
+                    "frame_count": len(values),
+                    **{
+                        name: f"{value:.6f}"
+                        for name, value
+                        in statistics.items()
+                    },
+                }
+            )
+
+    return output_path
+
+
+def main() -> None:
+    measurements = load_measurements()
+
+    trial_summary_path = write_trial_summary(
+        measurements
+    )
+    overall_summary_path = write_overall_summary(
+        measurements
+    )
+
+    print(
+        f"Trial summary created: {trial_summary_path}"
+    )
+    print(
+        f"Overall summary created: "
+        f"{overall_summary_path}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/analysis/analyze_results.py
+++ b/benchmarks/analysis/analyze_results.py
@@ -89,11 +89,9 @@ def load_measurements() -> list[Measurement]:
         result_path = RESULTS_DIRECTORY / file_name
 
         if not result_path.is_file():
-            print(
-                f"Warning: result file not found: "
-                f"{result_path}"
+            raise FileNotFoundError(
+                f"Required result file not found: {result_path}"
             )
-            continue
 
         with result_path.open(
             "r",

--- a/benchmarks/config/benchmark_config.json
+++ b/benchmarks/config/benchmark_config.json
@@ -1,0 +1,51 @@
+{
+  "input": {
+    "video_path": "benchmarks/data/benchmark_input.mp4"
+  },
+  "benchmark": {
+    "warmup_frames": 30,
+    "measured_frames": 500,
+    "trials": 5
+  },
+  "resolutions": [
+    {
+      "width": 640,
+      "height": 480
+    },
+    {
+      "width": 1280,
+      "height": 720
+    },
+    {
+      "width": 1920,
+      "height": 1080
+    }
+  ],
+  "algorithms": [
+    {
+      "name": "original",
+      "parameters": {}
+    },
+    {
+      "name": "gamma_correction",
+      "parameters": {
+        "gamma_value": 0.6
+      }
+    },
+    {
+      "name": "histogram_equalization",
+      "parameters": {}
+    },
+    {
+      "name": "clahe",
+      "parameters": {
+        "clip_limit": 4.0,
+        "grid_size": 8
+      }
+    }
+  ],
+  "output": {
+    "directory": "benchmarks/results",
+    "save_per_frame_results": true
+  }
+}

--- a/benchmarks/config/benchmark_config.json
+++ b/benchmarks/config/benchmark_config.json
@@ -45,7 +45,6 @@
     }
   ],
   "output": {
-    "directory": "benchmarks/results",
-    "save_per_frame_results": true
+    "directory": "benchmarks/results"
   }
 }

--- a/benchmarks/data/README.md
+++ b/benchmarks/data/README.md
@@ -1,0 +1,52 @@
+# Benchmark Input Data
+
+This directory contains the recorded input video used by all VisionLab benchmark implementations.
+
+## Required File
+
+Place the benchmark video at:
+
+```text
+benchmarks/data/benchmark_input.mp4
+```
+
+The video file is excluded from Git because of its size. It must not be committed to the repository.
+
+## Recommended Video Properties
+
+* Resolution: 1920×1080
+* Frame rate: 30 FPS
+* Duration: at least 20 seconds
+* Format: MP4
+* Codec: H.264 or another codec supported by OpenCV
+* Color format: standard BGR-compatible video
+* Content: a scene containing shadows, highlights, textures, movement and different contrast levels
+
+The same unchanged video must be used for Pure C++, Hybrid Python+C++ and Pure Python benchmarks.
+
+## Reproducibility
+
+Record the following information before running the final experiments:
+
+* Video resolution
+* Frame rate
+* Duration
+* Codec
+* File size
+* Recording device
+* Recording conditions
+* SHA-256 hash
+
+On Windows, the SHA-256 hash can be calculated with:
+
+```powershell
+certutil -hashfile benchmarks\data\benchmark_input.mp4 SHA256
+```
+
+On Linux:
+
+```bash
+sha256sum benchmarks/data/benchmark_input.mp4
+```
+
+Store the original benchmark video in a safe external location so the experiments can be repeated later.

--- a/benchmarks/runners/hybrid_benchmark.py
+++ b/benchmarks/runners/hybrid_benchmark.py
@@ -20,6 +20,36 @@ CONFIG_PATH = (
 DLL_DIRECTORY_HANDLES = []
 
 
+def is_release_candidate(
+    candidate: Path,
+    build_directory: Path,
+) -> bool:
+    if "release" in str(candidate.parent).lower():
+        return True
+
+    cache_path = build_directory / "CMakeCache.txt"
+
+    if not cache_path.is_file():
+        return False
+
+    with cache_path.open(
+        "r",
+        encoding="utf-8",
+    ) as cache_file:
+        for line in cache_file:
+            if line.startswith(
+                "CMAKE_BUILD_TYPE:STRING="
+            ):
+                return (
+                    line.removeprefix(
+                        "CMAKE_BUILD_TYPE:STRING="
+                    ).strip().lower()
+                    == "release"
+                )
+
+    return False
+
+
 def find_module_directory() -> Path:
     configured_directory = os.getenv(
         "VISIONLAB_CPP_MODULE_DIR"
@@ -53,7 +83,10 @@ def find_module_directory() -> Path:
     release_candidates = [
         candidate
         for candidate in candidates
-        if "release" in str(candidate.parent).lower()
+        if is_release_candidate(
+            candidate,
+            build_directory,
+        )
     ]
 
     if not release_candidates:

--- a/benchmarks/runners/hybrid_benchmark.py
+++ b/benchmarks/runners/hybrid_benchmark.py
@@ -1,0 +1,342 @@
+import csv
+import json
+import os
+import sys
+from pathlib import Path
+from time import perf_counter_ns
+
+import cv2
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+HYBRID_PROJECT_DIR = PROJECT_ROOT / "hybrid-python-cpp"
+CONFIG_PATH = (
+    PROJECT_ROOT
+    / "benchmarks"
+    / "config"
+    / "benchmark_config.json"
+)
+
+DLL_DIRECTORY_HANDLES = []
+
+
+def find_module_directory() -> Path:
+    configured_directory = os.getenv(
+        "VISIONLAB_CPP_MODULE_DIR"
+    )
+
+    if configured_directory:
+        module_directory = Path(
+            configured_directory
+        ).resolve()
+
+        if not module_directory.is_dir():
+            raise FileNotFoundError(
+                "VISIONLAB_CPP_MODULE_DIR geçerli değil: "
+                f"{module_directory}"
+            )
+
+        return module_directory
+
+    build_directory = HYBRID_PROJECT_DIR / "build"
+
+    candidates = []
+
+    for pattern in (
+        "visionlab_cpp*.pyd",
+        "visionlab_cpp*.so",
+    ):
+        candidates.extend(
+            build_directory.rglob(pattern)
+        )
+
+    release_candidates = [
+        candidate
+        for candidate in candidates
+        if "release" in str(candidate.parent).lower()
+    ]
+
+    if not release_candidates:
+        raise FileNotFoundError(
+            "Release modundaki visionlab_cpp modülü "
+            "bulunamadı. Önce hybrid projeyi Release "
+            "modunda derleyin veya "
+            "VISIONLAB_CPP_MODULE_DIR değişkenini ayarlayın."
+        )
+
+    newest_module = max(
+        release_candidates,
+        key=lambda path: path.stat().st_mtime,
+    )
+
+    return newest_module.parent
+
+
+MODULE_DIRECTORY = find_module_directory()
+sys.path.insert(0, str(MODULE_DIRECTORY))
+
+if os.name == "nt" and hasattr(
+    os,
+    "add_dll_directory",
+):
+    DLL_DIRECTORY_HANDLES.append(
+        os.add_dll_directory(
+            str(MODULE_DIRECTORY)
+        )
+    )
+
+import visionlab_cpp  # noqa: E402
+
+
+ALGORITHM_MAP = {
+    "original": (
+        visionlab_cpp.ProcessingAlgorithm.ORIGINAL
+    ),
+    "gamma_correction": (
+        visionlab_cpp.ProcessingAlgorithm.GAMMA
+    ),
+    "histogram_equalization": (
+        visionlab_cpp.ProcessingAlgorithm.HISTOGRAM
+    ),
+    "clahe": (
+        visionlab_cpp.ProcessingAlgorithm.CLAHE
+    ),
+}
+
+
+def load_config() -> dict:
+    with CONFIG_PATH.open(
+        "r",
+        encoding="utf-8",
+    ) as config_file:
+        return json.load(config_file)
+
+
+def read_frame(
+    capture: cv2.VideoCapture,
+):
+    frame_received, frame = capture.read()
+
+    if frame_received:
+        return frame
+
+    capture.set(cv2.CAP_PROP_POS_FRAMES, 0)
+    frame_received, frame = capture.read()
+
+    if not frame_received:
+        raise RuntimeError(
+            "Benchmark videosundan kare okunamadı."
+        )
+
+    return frame
+
+
+def run_test_case(
+    writer: csv.DictWriter,
+    video_path: Path,
+    algorithm_name: str,
+    algorithm,
+    gamma_value: float,
+    clahe_clip_limit: float,
+    clahe_grid_size: int,
+    width: int,
+    height: int,
+    trial: int,
+    warmup_frames: int,
+    measured_frames: int,
+) -> None:
+    capture = cv2.VideoCapture(str(video_path))
+
+    if not capture.isOpened():
+        capture.release()
+        raise RuntimeError(
+            f"Benchmark videosu açılamadı: {video_path}"
+        )
+
+    try:
+        for _ in range(warmup_frames):
+            frame = read_frame(capture)
+            resized_frame = cv2.resize(
+                frame,
+                (width, height),
+                interpolation=cv2.INTER_LINEAR,
+            )
+
+            visionlab_cpp.process_frame(
+                resized_frame,
+                algorithm,
+                gamma_value=gamma_value,
+                clahe_clip_limit=clahe_clip_limit,
+                clahe_grid_size=clahe_grid_size,
+            )
+
+        for frame_index in range(1, measured_frames + 1):
+            frame = read_frame(capture)
+            resized_frame = cv2.resize(
+                frame,
+                (width, height),
+                interpolation=cv2.INTER_LINEAR,
+            )
+
+            start_time = perf_counter_ns()
+
+            processed_frame = visionlab_cpp.process_frame(
+                resized_frame,
+                algorithm,
+                gamma_value=gamma_value,
+                clahe_clip_limit=clahe_clip_limit,
+                clahe_grid_size=clahe_grid_size,
+            )
+
+            process_time_ms = (
+                perf_counter_ns() - start_time
+            ) / 1_000_000.0
+
+            if processed_frame.size == 0:
+                raise RuntimeError(
+                    "C++ modülü boş görüntü üretti."
+                )
+
+            writer.writerow(
+                {
+                    "architecture": "hybrid",
+                    "algorithm": algorithm_name,
+                    "resolution": f"{width}x{height}",
+                    "trial": trial,
+                    "frame_index": frame_index,
+                    "processing_time_ms": (
+                        f"{process_time_ms:.6f}"
+                    ),
+                }
+            )
+    finally:
+        capture.release()
+
+
+def main() -> None:
+    config = load_config()
+
+    video_path = (
+        PROJECT_ROOT
+        / config["input"]["video_path"]
+    ).resolve()
+
+    if not video_path.is_file():
+        raise FileNotFoundError(
+            "Benchmark videosu bulunamadı: "
+            f"{video_path}"
+        )
+
+    benchmark_config = config["benchmark"]
+    warmup_frames = int(
+        benchmark_config["warmup_frames"]
+    )
+    measured_frames = int(
+        benchmark_config["measured_frames"]
+    )
+    trials = int(benchmark_config["trials"])
+
+    output_directory = (
+        PROJECT_ROOT
+        / config["output"]["directory"]
+    ).resolve()
+    output_directory.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    output_path = (
+        output_directory
+        / "hybrid_results.csv"
+    )
+
+    fieldnames = [
+        "architecture",
+        "algorithm",
+        "resolution",
+        "trial",
+        "frame_index",
+        "processing_time_ms",
+    ]
+
+    with output_path.open(
+        "w",
+        newline="",
+        encoding="utf-8",
+    ) as output_file:
+        writer = csv.DictWriter(
+            output_file,
+            fieldnames=fieldnames,
+        )
+        writer.writeheader()
+
+        for resolution in config["resolutions"]:
+            width = int(resolution["width"])
+            height = int(resolution["height"])
+
+            for algorithm_config in config["algorithms"]:
+                algorithm_name = algorithm_config["name"]
+
+                if algorithm_name not in ALGORITHM_MAP:
+                    raise ValueError(
+                        "Desteklenmeyen algoritma: "
+                        f"{algorithm_name}"
+                    )
+
+                parameters = algorithm_config.get(
+                    "parameters",
+                    {},
+                )
+
+                gamma_value = float(
+                    parameters.get(
+                        "gamma_value",
+                        0.6,
+                    )
+                )
+                clahe_clip_limit = float(
+                    parameters.get(
+                        "clip_limit",
+                        4.0,
+                    )
+                )
+                clahe_grid_size = int(
+                    parameters.get(
+                        "grid_size",
+                        8,
+                    )
+                )
+
+                for trial in range(1, trials + 1):
+                    print(
+                        f"Hybrid | {algorithm_name} | "
+                        f"{width}x{height} | "
+                        f"trial {trial}/{trials}"
+                    )
+
+                    run_test_case(
+                        writer=writer,
+                        video_path=video_path,
+                        algorithm_name=algorithm_name,
+                        algorithm=(
+                            ALGORITHM_MAP[algorithm_name]
+                        ),
+                        gamma_value=gamma_value,
+                        clahe_clip_limit=(
+                            clahe_clip_limit
+                        ),
+                        clahe_grid_size=clahe_grid_size,
+                        width=width,
+                        height=height,
+                        trial=trial,
+                        warmup_frames=warmup_frames,
+                        measured_frames=measured_frames,
+                    )
+
+                    output_file.flush()
+
+    print(f"Benchmark tamamlandı: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/runners/pure_cpp_benchmark.cpp
+++ b/benchmarks/runners/pure_cpp_benchmark.cpp
@@ -1,0 +1,480 @@
+#include "imageprocess.h"
+
+#include <QFile>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonParseError>
+#include <QString>
+
+#include <opencv2/imgproc.hpp>
+#include <opencv2/videoio.hpp>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#ifndef VISIONLAB_PROJECT_ROOT
+#error "VISIONLAB_PROJECT_ROOT is not defined."
+#endif
+
+namespace
+{
+
+namespace fs = std::filesystem;
+
+struct Resolution
+{
+    int width;
+    int height;
+};
+
+struct AlgorithmConfiguration
+{
+    std::string name;
+    ProcessingAlgorithm algorithm;
+    ProcessingParameters parameters;
+};
+
+struct BenchmarkConfiguration
+{
+    fs::path videoPath;
+    fs::path outputDirectory;
+    int warmupFrames;
+    int measuredFrames;
+    int trials;
+    std::vector<Resolution> resolutions;
+    std::vector<AlgorithmConfiguration> algorithms;
+};
+
+ProcessingAlgorithm algorithmFromName(
+    const std::string &name
+)
+{
+    if (name == "original")
+    {
+        return ProcessingAlgorithm::Original;
+    }
+
+    if (name == "gamma_correction")
+    {
+        return ProcessingAlgorithm::GammaCorrection;
+    }
+
+    if (name == "histogram_equalization")
+    {
+        return ProcessingAlgorithm::HistogramEqualization;
+    }
+
+    if (name == "clahe")
+    {
+        return ProcessingAlgorithm::Clahe;
+    }
+
+    throw std::invalid_argument(
+        "Unsupported algorithm: " + name
+    );
+}
+
+BenchmarkConfiguration loadConfiguration(
+    const fs::path &projectRoot
+)
+{
+    const fs::path configPath =
+        projectRoot
+        / "benchmarks"
+        / "config"
+        / "benchmark_config.json";
+
+    QFile configFile(
+        QString::fromStdString(
+            configPath.generic_string()
+        )
+    );
+
+    if (!configFile.open(QIODevice::ReadOnly))
+    {
+        throw std::runtime_error(
+            "Could not open benchmark configuration: "
+            + configPath.string()
+        );
+    }
+
+    QJsonParseError parseError;
+
+    const QJsonDocument document =
+        QJsonDocument::fromJson(
+            configFile.readAll(),
+            &parseError
+        );
+
+    if (parseError.error !=
+        QJsonParseError::NoError)
+    {
+        throw std::runtime_error(
+            "Invalid benchmark JSON: "
+            + parseError.errorString().toStdString()
+        );
+    }
+
+    if (!document.isObject())
+    {
+        throw std::runtime_error(
+            "Benchmark configuration must be an object."
+        );
+    }
+
+    const QJsonObject root = document.object();
+    const QJsonObject input =
+        root.value("input").toObject();
+    const QJsonObject benchmark =
+        root.value("benchmark").toObject();
+    const QJsonObject output =
+        root.value("output").toObject();
+
+    BenchmarkConfiguration configuration;
+
+    configuration.videoPath =
+        projectRoot
+        / input.value("video_path")
+              .toString()
+              .toStdString();
+
+    configuration.outputDirectory =
+        projectRoot
+        / output.value("directory")
+              .toString()
+              .toStdString();
+
+    configuration.warmupFrames =
+        benchmark.value("warmup_frames").toInt(-1);
+
+    configuration.measuredFrames =
+        benchmark.value("measured_frames").toInt(-1);
+
+    configuration.trials =
+        benchmark.value("trials").toInt(-1);
+
+    if (configuration.warmupFrames < 0 ||
+        configuration.measuredFrames <= 0 ||
+        configuration.trials <= 0)
+    {
+        throw std::runtime_error(
+            "Invalid benchmark frame or trial counts."
+        );
+    }
+
+    const QJsonArray resolutionArray =
+        root.value("resolutions").toArray();
+
+    for (const QJsonValue &value : resolutionArray)
+    {
+        const QJsonObject object = value.toObject();
+
+        Resolution resolution{
+            object.value("width").toInt(-1),
+            object.value("height").toInt(-1)
+        };
+
+        if (resolution.width <= 0 ||
+            resolution.height <= 0)
+        {
+            throw std::runtime_error(
+                "Invalid benchmark resolution."
+            );
+        }
+
+        configuration.resolutions.push_back(
+            resolution
+        );
+    }
+
+    const QJsonArray algorithmArray =
+        root.value("algorithms").toArray();
+
+    for (const QJsonValue &value : algorithmArray)
+    {
+        const QJsonObject object = value.toObject();
+        const QJsonObject parameters =
+            object.value("parameters").toObject();
+
+        AlgorithmConfiguration algorithmConfig;
+
+        algorithmConfig.name =
+            object.value("name")
+                .toString()
+                .toStdString();
+
+        algorithmConfig.algorithm =
+            algorithmFromName(
+                algorithmConfig.name
+            );
+
+        algorithmConfig.parameters.gammaValue =
+            parameters.value("gamma_value")
+                .toDouble(0.6);
+
+        algorithmConfig.parameters.claheClipLimit =
+            parameters.value("clip_limit")
+                .toDouble(4.0);
+
+        algorithmConfig.parameters.claheGridSize =
+            parameters.value("grid_size")
+                .toInt(8);
+
+        configuration.algorithms.push_back(
+            algorithmConfig
+        );
+    }
+
+    if (configuration.resolutions.empty() ||
+        configuration.algorithms.empty())
+    {
+        throw std::runtime_error(
+            "Benchmark configuration is incomplete."
+        );
+    }
+
+    return configuration;
+}
+
+cv::Mat readFrame(cv::VideoCapture &capture)
+{
+    cv::Mat frame;
+
+    if (capture.read(frame) && !frame.empty())
+    {
+        return frame;
+    }
+
+    capture.set(cv::CAP_PROP_POS_FRAMES, 0);
+
+    if (!capture.read(frame) || frame.empty())
+    {
+        throw std::runtime_error(
+            "Could not read a frame from the video."
+        );
+    }
+
+    return frame;
+}
+
+void runTestCase(
+    std::ofstream &output,
+    const ImageProcess &processor,
+    const BenchmarkConfiguration &configuration,
+    const Resolution &resolution,
+    const AlgorithmConfiguration &algorithm,
+    int trial
+)
+{
+    cv::VideoCapture capture(
+        configuration.videoPath.string()
+    );
+
+    if (!capture.isOpened())
+    {
+        throw std::runtime_error(
+            "Could not open benchmark video: "
+            + configuration.videoPath.string()
+        );
+    }
+
+    for (int index = 0;
+         index < configuration.warmupFrames;
+         ++index)
+    {
+        const cv::Mat frame = readFrame(capture);
+
+        cv::Mat resizedFrame;
+        cv::resize(
+            frame,
+            resizedFrame,
+            cv::Size(
+                resolution.width,
+                resolution.height
+            ),
+            0.0,
+            0.0,
+            cv::INTER_LINEAR
+        );
+
+        cv::Mat processedFrame;
+
+        processor.process(
+            resizedFrame,
+            processedFrame,
+            algorithm.algorithm,
+            algorithm.parameters
+        );
+    }
+
+    for (int frameIndex = 1;
+         frameIndex <= configuration.measuredFrames;
+         ++frameIndex)
+    {
+        const cv::Mat frame = readFrame(capture);
+
+        cv::Mat resizedFrame;
+        cv::resize(
+            frame,
+            resizedFrame,
+            cv::Size(
+                resolution.width,
+                resolution.height
+            ),
+            0.0,
+            0.0,
+            cv::INTER_LINEAR
+        );
+
+        cv::Mat processedFrame;
+
+        const auto startTime =
+            std::chrono::steady_clock::now();
+
+        processor.process(
+            resizedFrame,
+            processedFrame,
+            algorithm.algorithm,
+            algorithm.parameters
+        );
+
+        const auto endTime =
+            std::chrono::steady_clock::now();
+
+        if (processedFrame.empty())
+        {
+            throw std::runtime_error(
+                "The algorithm produced an empty frame."
+            );
+        }
+
+        const double processTimeMs =
+            std::chrono::duration<
+                double,
+                std::milli
+            >(endTime - startTime).count();
+
+        output
+            << "pure_cpp,"
+            << algorithm.name << ','
+            << resolution.width << 'x'
+            << resolution.height << ','
+            << trial << ','
+            << frameIndex << ','
+            << processTimeMs
+            << '\n';
+    }
+}
+
+} // namespace
+
+int main()
+{
+    try
+    {
+        const fs::path projectRoot =
+            fs::path(VISIONLAB_PROJECT_ROOT)
+                .lexically_normal();
+
+        const BenchmarkConfiguration configuration =
+            loadConfiguration(projectRoot);
+
+        if (!fs::is_regular_file(
+                configuration.videoPath
+            ))
+        {
+            throw std::runtime_error(
+                "Benchmark video was not found: "
+                + configuration.videoPath.string()
+            );
+        }
+
+        fs::create_directories(
+            configuration.outputDirectory
+        );
+
+        const fs::path outputPath =
+            configuration.outputDirectory
+            / "pure_cpp_results.csv";
+
+        std::ofstream output(outputPath);
+
+        if (!output.is_open())
+        {
+            throw std::runtime_error(
+                "Could not create result file: "
+                + outputPath.string()
+            );
+        }
+
+        output
+            << "architecture,algorithm,resolution,"
+            << "trial,frame_index,processing_time_ms\n";
+
+        output
+            << std::fixed
+            << std::setprecision(6);
+
+        const ImageProcess processor;
+
+        for (const Resolution &resolution :
+             configuration.resolutions)
+        {
+            for (const AlgorithmConfiguration &algorithm :
+                 configuration.algorithms)
+            {
+                for (int trial = 1;
+                     trial <= configuration.trials;
+                     ++trial)
+                {
+                    std::cout
+                        << "Pure C++ | "
+                        << algorithm.name
+                        << " | "
+                        << resolution.width
+                        << 'x'
+                        << resolution.height
+                        << " | trial "
+                        << trial
+                        << '/'
+                        << configuration.trials
+                        << '\n';
+
+                    runTestCase(
+                        output,
+                        processor,
+                        configuration,
+                        resolution,
+                        algorithm,
+                        trial
+                    );
+
+                    output.flush();
+                }
+            }
+        }
+
+        std::cout
+            << "Benchmark completed: "
+            << outputPath
+            << '\n';
+
+        return 0;
+    }
+    catch (const std::exception &exception)
+    {
+        std::cerr
+            << "Benchmark failed: "
+            << exception.what()
+            << '\n';
+
+        return 1;
+    }
+}

--- a/benchmarks/runners/pure_python_benchmark.py
+++ b/benchmarks/runners/pure_python_benchmark.py
@@ -1,0 +1,262 @@
+import csv
+import json
+import sys
+from pathlib import Path
+from time import perf_counter_ns
+
+import cv2
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+PURE_PYTHON_DIR = PROJECT_ROOT / "pure-python"
+CONFIG_PATH = (
+    PROJECT_ROOT
+    / "benchmarks"
+    / "config"
+    / "benchmark_config.json"
+)
+
+sys.path.insert(0, str(PURE_PYTHON_DIR))
+
+from image_process import (  # noqa: E402
+    ImageProcess,
+    ProcessingAlgorithm,
+    ProcessingParameters,
+)
+
+
+ALGORITHM_MAP = {
+    "original": ProcessingAlgorithm.ORIGINAL,
+    "gamma_correction": ProcessingAlgorithm.GAMMA,
+    "histogram_equalization": ProcessingAlgorithm.HISTOGRAM,
+    "clahe": ProcessingAlgorithm.CLAHE,
+}
+
+
+def load_config() -> dict:
+    with CONFIG_PATH.open(
+        "r",
+        encoding="utf-8",
+    ) as config_file:
+        return json.load(config_file)
+
+
+def create_parameters(
+    algorithm_config: dict,
+) -> ProcessingParameters:
+    parameters = algorithm_config.get("parameters", {})
+
+    return ProcessingParameters(
+        gamma_value=float(
+            parameters.get("gamma_value", 0.6)
+        ),
+        clahe_clip_limit=float(
+            parameters.get("clip_limit", 4.0)
+        ),
+        clahe_grid_size=int(
+            parameters.get("grid_size", 8)
+        ),
+    )
+
+
+def read_frame(
+    capture: cv2.VideoCapture,
+):
+    frame_received, frame = capture.read()
+
+    if frame_received:
+        return frame
+
+    capture.set(cv2.CAP_PROP_POS_FRAMES, 0)
+    frame_received, frame = capture.read()
+
+    if not frame_received:
+        raise RuntimeError(
+            "Benchmark videosundan kare okunamadı."
+        )
+
+    return frame
+
+
+def run_test_case(
+    writer: csv.DictWriter,
+    processor: ImageProcess,
+    video_path: Path,
+    algorithm_name: str,
+    algorithm: ProcessingAlgorithm,
+    parameters: ProcessingParameters,
+    width: int,
+    height: int,
+    trial: int,
+    warmup_frames: int,
+    measured_frames: int,
+) -> None:
+    capture = cv2.VideoCapture(str(video_path))
+
+    if not capture.isOpened():
+        capture.release()
+        raise RuntimeError(
+            f"Benchmark videosu açılamadı: {video_path}"
+        )
+
+    try:
+        for _ in range(warmup_frames):
+            frame = read_frame(capture)
+            resized_frame = cv2.resize(
+                frame,
+                (width, height),
+                interpolation=cv2.INTER_LINEAR,
+            )
+
+            processor.process(
+                resized_frame,
+                algorithm,
+                parameters,
+            )
+
+        for frame_index in range(1, measured_frames + 1):
+            frame = read_frame(capture)
+            resized_frame = cv2.resize(
+                frame,
+                (width, height),
+                interpolation=cv2.INTER_LINEAR,
+            )
+
+            start_time = perf_counter_ns()
+
+            processed_frame = processor.process(
+                resized_frame,
+                algorithm,
+                parameters,
+            )
+
+            process_time_ms = (
+                perf_counter_ns() - start_time
+            ) / 1_000_000.0
+
+            if processed_frame.size == 0:
+                raise RuntimeError(
+                    "Algoritma boş görüntü üretti."
+                )
+
+            writer.writerow(
+                {
+                    "architecture": "pure_python",
+                    "algorithm": algorithm_name,
+                    "resolution": f"{width}x{height}",
+                    "trial": trial,
+                    "frame_index": frame_index,
+                    "processing_time_ms": (
+                        f"{process_time_ms:.6f}"
+                    ),
+                }
+            )
+    finally:
+        capture.release()
+
+
+def main() -> None:
+    config = load_config()
+
+    video_path = (
+        PROJECT_ROOT
+        / config["input"]["video_path"]
+    ).resolve()
+
+    if not video_path.is_file():
+        raise FileNotFoundError(
+            "Benchmark videosu bulunamadı: "
+            f"{video_path}"
+        )
+
+    benchmark_config = config["benchmark"]
+    warmup_frames = int(
+        benchmark_config["warmup_frames"]
+    )
+    measured_frames = int(
+        benchmark_config["measured_frames"]
+    )
+    trials = int(benchmark_config["trials"])
+
+    output_directory = (
+        PROJECT_ROOT
+        / config["output"]["directory"]
+    ).resolve()
+    output_directory.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    output_path = (
+        output_directory
+        / "pure_python_results.csv"
+    )
+
+    processor = ImageProcess()
+
+    fieldnames = [
+        "architecture",
+        "algorithm",
+        "resolution",
+        "trial",
+        "frame_index",
+        "processing_time_ms",
+    ]
+
+    with output_path.open(
+        "w",
+        newline="",
+        encoding="utf-8",
+    ) as output_file:
+        writer = csv.DictWriter(
+            output_file,
+            fieldnames=fieldnames,
+        )
+        writer.writeheader()
+
+        for resolution in config["resolutions"]:
+            width = int(resolution["width"])
+            height = int(resolution["height"])
+
+            for algorithm_config in config["algorithms"]:
+                algorithm_name = algorithm_config["name"]
+
+                if algorithm_name not in ALGORITHM_MAP:
+                    raise ValueError(
+                        "Desteklenmeyen algoritma: "
+                        f"{algorithm_name}"
+                    )
+
+                algorithm = ALGORITHM_MAP[algorithm_name]
+                parameters = create_parameters(
+                    algorithm_config
+                )
+
+                for trial in range(1, trials + 1):
+                    print(
+                        f"Pure Python | {algorithm_name} | "
+                        f"{width}x{height} | "
+                        f"trial {trial}/{trials}"
+                    )
+
+                    run_test_case(
+                        writer=writer,
+                        processor=processor,
+                        video_path=video_path,
+                        algorithm_name=algorithm_name,
+                        algorithm=algorithm,
+                        parameters=parameters,
+                        width=width,
+                        height=height,
+                        trial=trial,
+                        warmup_frames=warmup_frames,
+                        measured_frames=measured_frames,
+                    )
+
+                    output_file.flush()
+
+    print(f"Benchmark tamamlandı: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/cpp-opencv-core/CMakeLists.txt
+++ b/cpp-opencv-core/CMakeLists.txt
@@ -44,15 +44,75 @@ target_link_libraries(VisionLabCore PRIVATE
     Qt6::OpenGLWidgets
 )
 
+add_executable(
+    VisionLabCppBenchmark
+
+    ../benchmarks/runners/pure_cpp_benchmark.cpp
+    src/imageprocess.h
+    src/imageprocess.cpp
+)
+
+target_include_directories(
+    VisionLabCppBenchmark
+    PRIVATE
+
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+    ${OpenCV_INCLUDE_DIRS}
+)
+
+target_link_libraries(
+    VisionLabCppBenchmark
+    PRIVATE
+
+    ${OpenCV_LIBS}
+    Qt6::Core
+)
+
+target_compile_definitions(
+    VisionLabCppBenchmark
+    PRIVATE
+
+    VISIONLAB_PROJECT_ROOT="${CMAKE_CURRENT_SOURCE_DIR}/.."
+)
+
 if(WIN32)
-    file(GLOB OPENCV_RUNTIME_DLLS
+    file(
+        GLOB OPENCV_RUNTIME_DLLS
         "C:/opencv/build/x64/vc16/bin/*.dll"
     )
 
-    add_custom_command(TARGET VisionLabCore POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    if(OPENCV_RUNTIME_DLLS)
+        add_custom_command(
+            TARGET VisionLabCore
+            POST_BUILD
+
+            COMMAND
+                ${CMAKE_COMMAND}
+                -E copy_if_different
                 ${OPENCV_RUNTIME_DLLS}
                 $<TARGET_FILE_DIR:VisionLabCore>
-        COMMENT "Copying OpenCV runtime DLL files"
-    )
+
+            COMMENT
+                "Copying OpenCV runtime DLL files"
+        )
+
+        add_custom_command(
+            TARGET VisionLabCppBenchmark
+            POST_BUILD
+
+            COMMAND
+                ${CMAKE_COMMAND}
+                -E copy_if_different
+                ${OPENCV_RUNTIME_DLLS}
+                $<TARGET_FILE_DIR:VisionLabCppBenchmark>
+
+            COMMENT
+                "Copying OpenCV runtime DLL files for benchmark"
+        )
+    else()
+        message(
+            WARNING
+            "OpenCV runtime DLL files were not found."
+        )
+    endif()
 endif()


### PR DESCRIPTION
## Summary

This PR adds a reproducible benchmark framework for comparing the three VisionLab architectures:

* Pure C++ with OpenCV
* Hybrid Python+C++ using pybind11
* Pure Python with OpenCV

## Changes

* Added a shared JSON benchmark configuration
* Added benchmark runners for all three architectures
* Added a dedicated Release-mode C++ benchmark target
* Added per-frame processing time export in a consistent CSV format
* Added trial-level and overall statistical analysis
* Added benchmark input and execution documentation
* Excluded benchmark videos and generated result files from Git

## Measurements

The framework calculates:

* Mean processing time
* Median processing time
* Minimum and maximum processing time
* Population standard deviation
* 95th percentile processing time
* Effective processing FPS

Camera capture, frame resizing and GUI rendering are excluded from the timed section.

The Hybrid measurement includes the Python-to-C++ call and the result transfer back to NumPy.

## Validation

A smoke test was completed for all three architectures using:

* 3 resolutions
* 4 algorithms
* 20 measured frames
* 1 trial

Each architecture successfully generated 240 measurements plus the CSV header.

The Pure C++ benchmark was built and executed in Release mode.

The analysis script successfully generated both trial-level and overall summary files.

## Generated Outputs

```text
pure_python_results.csv
hybrid_results.csv
pure_cpp_results.csv
benchmark_trial_summary.csv
benchmark_summary.csv
```

Closes #9