### PR TITLE
fix: strengthen benchmark integrity and reproducibility

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,8 +1,14 @@
 # VisionLab Benchmark Reproducibility Guide
 
-Follow this guide from the repository root (`VisionLab/`) to reproduce the benchmark results across all three implementations.
+This guide explains how to reproduce the VisionLab benchmarks across the following implementations:
 
-## 1) Prepare input video
+* Pure Python
+* Hybrid Python+C++
+* Pure C++
+
+Run all commands from the repository root (`VisionLab/`) unless otherwise specified.
+
+## 1. Prepare the input video
 
 Place the benchmark video at:
 
@@ -10,91 +16,365 @@ Place the benchmark video at:
 benchmarks/data/benchmark_input.mp4
 ```
 
-Detailed input requirements are documented in `benchmarks/data/README.md`.
+Detailed input requirements are documented in:
 
-## 2) Install dependencies
+```text
+benchmarks/data/README.md
+```
 
-### Pure Python runner
+All implementations must use the same input video and benchmark configuration.
+
+The shared configuration file is:
+
+```text
+benchmarks/config/benchmark_config.json
+```
+
+It defines:
+
+* Warm-up frame count
+* Measured frame count
+* Trial count
+* Resolutions
+* Algorithms and their parameters
+
+Do not change the configuration between architecture runs.
+
+## 2. Requirements
+
+The project requires:
+
+* Python 3
+* CMake 3.15 or newer
+* A C++17-compatible compiler
+* OpenCV
+* Qt6 Core, Gui, Widgets and OpenGLWidgets
+* Python packages listed in the project requirement files
+
+The C++ and Hybrid implementations must be built in Release mode for official measurements.
+
+## 3. Linux and macOS setup
+
+### 3.1. Pure Python environment
 
 ```bash
-cd pure-python
-python3 -m venv .venv
-source .venv/bin/activate
+python3 -m venv pure-python/.venv
+source pure-python/.venv/bin/activate
+
 python -m pip install --upgrade pip
-python -m pip install -r requirements.txt
-cd ..
+python -m pip install -r pure-python/requirements.txt
+
+deactivate
 ```
 
-### Hybrid Python+C++ runner
+### 3.2. Hybrid Python+C++ environment
 
 ```bash
-cd hybrid-python-cpp
-python3 -m venv .venv
-source .venv/bin/activate
+python3 -m venv hybrid-python-cpp/.venv
+source hybrid-python-cpp/.venv/bin/activate
+
 python -m pip install --upgrade pip
-python -m pip install -r requirements.txt
-cd ..
+python -m pip install -r hybrid-python-cpp/requirements.txt
+
+deactivate
 ```
 
-### C++ benchmark executable
+## 4. Build Release binaries
 
-Install system dependencies required by CMake for:
+### 4.1. Hybrid module
 
-- C++17 compiler toolchain
-- OpenCV development package
-- Qt6 Core/Gui/Widgets/OpenGLWidgets
-
-## 3) Build Release binaries
-
-### Hybrid module (Release)
+Activate the Hybrid environment before configuring CMake:
 
 ```bash
-cmake -S hybrid-python-cpp -B hybrid-python-cpp/build -DCMAKE_BUILD_TYPE=Release
-cmake --build hybrid-python-cpp/build --config Release
+source hybrid-python-cpp/.venv/bin/activate
+
+cmake \
+    -S hybrid-python-cpp \
+    -B hybrid-python-cpp/build \
+    -DCMAKE_BUILD_TYPE=Release
+
+cmake \
+    --build hybrid-python-cpp/build \
+    --config Release
+
+deactivate
 ```
 
-### Pure C++ benchmark executable (Release)
+The build must create a Python module named similar to:
 
-```bash
-cmake -S cpp-opencv-core -B cpp-opencv-core/build -DCMAKE_BUILD_TYPE=Release
-cmake --build cpp-opencv-core/build --config Release --target VisionLabCppBenchmark
+```text
+visionlab_cpp.so
 ```
 
-## 4) Run benchmark runners
+On Windows, the module uses the `.pyd` extension.
 
-From repository root:
+### 4.2. Pure C++ benchmark
 
 ```bash
+cmake \
+    -S cpp-opencv-core \
+    -B cpp-opencv-core/build \
+    -DCMAKE_BUILD_TYPE=Release
+
+cmake \
+    --build cpp-opencv-core/build \
+    --config Release \
+    --target VisionLabCppBenchmark
+```
+
+The benchmark executable must not be run from a Debug build. Debug execution is intentionally rejected by the application.
+
+## 5. Run benchmarks on Linux and macOS
+
+Run the implementations in the following order.
+
+### 5.1. Pure Python
+
+```bash
+source pure-python/.venv/bin/activate
+
 python benchmarks/runners/pure_python_benchmark.py
-python benchmarks/runners/hybrid_benchmark.py
+
+deactivate
 ```
 
-Run pure C++ benchmark:
+### 5.2. Hybrid Python+C++
+
+Activate the Hybrid environment:
+
+```bash
+source hybrid-python-cpp/.venv/bin/activate
+```
+
+If the `visionlab_cpp` module is not located automatically, set the directory containing the compiled module:
+
+```bash
+export VISIONLAB_CPP_MODULE_DIR="/absolute/path/to/hybrid-python-cpp/build"
+```
+
+For multi-config generators, the module may be inside a configuration subdirectory:
+
+```bash
+export VISIONLAB_CPP_MODULE_DIR="/absolute/path/to/hybrid-python-cpp/build/Release"
+```
+
+Run the benchmark:
+
+```bash
+python benchmarks/runners/hybrid_benchmark.py
+
+deactivate
+```
+
+### 5.3. Pure C++
+
+For a single-config build:
 
 ```bash
 ./cpp-opencv-core/build/VisionLabCppBenchmark
-# or (multi-config generators)
+```
+
+For a multi-config build:
+
+```bash
 ./cpp-opencv-core/build/Release/VisionLabCppBenchmark
 ```
 
-If your generator places the hybrid module in a non-default location, set:
+## 6. Windows setup and execution
 
-```bash
-export VISIONLAB_CPP_MODULE_DIR=/absolute/path/to/hybrid-python-cpp/build[/Release]
+The recommended Windows configuration is a 64-bit MSVC kit with Release selected in Qt Creator.
+
+Qt Creator may place binaries in kit-specific directories such as:
+
+```text
+build/Desktop_Qt_6_11_1_MSVC2022_64bit-Release
 ```
 
-## 5) Run analysis
+Use the actual Release directory generated on your computer.
+
+### 6.1. PowerShell environments
+
+If PowerShell prevents virtual-environment activation, allow scripts for the current terminal:
+
+```powershell
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+```
+
+Create the Pure Python environment:
+
+```powershell
+py -3 -m venv pure-python\.venv
+.\pure-python\.venv\Scripts\Activate.ps1
+
+python -m pip install --upgrade pip
+python -m pip install -r pure-python\requirements.txt
+
+deactivate
+```
+
+Create the Hybrid environment:
+
+```powershell
+py -3 -m venv hybrid-python-cpp\.venv
+.\hybrid-python-cpp\.venv\Scripts\Activate.ps1
+
+python -m pip install --upgrade pip
+python -m pip install -r hybrid-python-cpp\requirements.txt
+
+deactivate
+```
+
+### 6.2. Build with Qt Creator
+
+For both `hybrid-python-cpp` and `cpp-opencv-core`:
+
+1. Open the corresponding `CMakeLists.txt` file in Qt Creator.
+2. Select a 64-bit MSVC desktop kit.
+3. Select the Release build configuration.
+4. Build the project.
+5. For the Pure C++ project, build the `VisionLabCppBenchmark` target.
+
+Do not use a Debug binary for official measurements.
+
+### 6.3. Run Pure Python in PowerShell
+
+```powershell
+.\pure-python\.venv\Scripts\Activate.ps1
+
+python benchmarks\runners\pure_python_benchmark.py
+
+deactivate
+```
+
+### 6.4. Locate and run the Hybrid module
+
+Locate the compiled module:
+
+```powershell
+Get-ChildItem hybrid-python-cpp\build -Recurse -Filter "visionlab_cpp*.pyd"
+```
+
+Activate the Hybrid environment and set the directory containing the `.pyd` file:
+
+```powershell
+.\hybrid-python-cpp\.venv\Scripts\Activate.ps1
+
+$env:VISIONLAB_CPP_MODULE_DIR="C:\path\to\VisionLab\hybrid-python-cpp\build\YOUR_RELEASE_DIRECTORY"
+
+python benchmarks\runners\hybrid_benchmark.py
+
+deactivate
+```
+
+Replace `YOUR_RELEASE_DIRECTORY` with the directory reported by Qt Creator or the preceding search command.
+
+### 6.5. Locate and run the Pure C++ benchmark
+
+Locate the executable:
+
+```powershell
+Get-ChildItem cpp-opencv-core\build -Recurse -Filter "VisionLabCppBenchmark.exe"
+```
+
+Run the Release executable:
+
+```powershell
+.\cpp-opencv-core\build\YOUR_RELEASE_DIRECTORY\VisionLabCppBenchmark.exe
+```
+
+If the following message appears, a Debug executable was selected:
+
+```text
+VisionLabCppBenchmark must be run in Release mode.
+```
+
+Switch to the Release build before continuing.
+
+### 6.6. Git Bash on Windows
+
+Run Pure Python:
+
+```bash
+source pure-python/.venv/Scripts/activate
+
+python benchmarks/runners/pure_python_benchmark.py
+
+deactivate
+```
+
+Run Hybrid Python+C++:
+
+```bash
+source hybrid-python-cpp/.venv/Scripts/activate
+
+export VISIONLAB_CPP_MODULE_DIR="C:/path/to/VisionLab/hybrid-python-cpp/build/YOUR_RELEASE_DIRECTORY"
+
+python benchmarks/runners/hybrid_benchmark.py
+
+deactivate
+```
+
+Run Pure C++:
+
+```bash
+./cpp-opencv-core/build/YOUR_RELEASE_DIRECTORY/VisionLabCppBenchmark.exe
+```
+
+## 7. Analyze the results
+
+Run the analyzer after all three benchmark runners finish successfully:
 
 ```bash
 python benchmarks/analysis/analyze_results.py
 ```
 
-## 6) Expected output files
+The analyzer validates the result files against the current benchmark configuration. It rejects:
 
-After a successful run, `benchmarks/results/` must contain:
+* Missing architecture, algorithm, resolution or trial groups
+* Missing frame indices
+* Duplicate frame indices
+* Unexpected frame indices
+* Incorrect architecture labels
+* Invalid processing-time values
+* Partial results generated with a different configuration
 
-- `pure_python_results.csv`
-- `hybrid_results.csv`
-- `pure_cpp_results.csv`
-- `benchmark_trial_summary.csv`
-- `benchmark_summary.csv`
+If the configuration changes, rerun all three implementations before analyzing the results.
+
+## 8. Expected output files
+
+After a successful benchmark and analysis run, `benchmarks/results/` must contain:
+
+```text
+pure_python_results.csv
+hybrid_results.csv
+pure_cpp_results.csv
+benchmark_trial_summary.csv
+benchmark_summary.csv
+```
+
+The first three files contain per-frame measurements. The final two files contain trial-level and overall statistics.
+
+With the default configuration, each architecture produces:
+
+```text
+4 algorithms × 3 resolutions × 5 trials × 500 measured frames
+= 30,000 measurement rows
+```
+
+Warm-up frames are not written to the result files.
+
+## 9. Fair-comparison requirements
+
+For scientifically meaningful results:
+
+* Use the same input video for all architectures.
+* Use the same benchmark configuration.
+* Build the Hybrid and Pure C++ implementations in Release mode.
+* Run all benchmarks on the same computer.
+* Keep power and performance settings unchanged.
+* Close unnecessary background applications.
+* Avoid running multiple benchmarks simultaneously.
+* Do not compare partial, smoke-test or Debug results with official results.
+* Record the hardware, operating system, compiler, Python, OpenCV and Qt versions used for the experiment.
+
+Generated result files should only be compared after the analyzer completes without an integrity error.

--- a/benchmarks/analysis/analyze_results.py
+++ b/benchmarks/analysis/analyze_results.py
@@ -17,12 +17,11 @@ CONFIG_PATH = (
     / "benchmark_config.json"
 )
 
-RESULT_FILES = [
-    "pure_python_results.csv",
-    "hybrid_results.csv",
-    "pure_cpp_results.csv",
-]
-
+RESULT_FILES = {
+    "pure_python_results.csv": "pure_python",
+    "hybrid_results.csv": "hybrid",
+    "pure_cpp_results.csv": "pure_cpp",
+}
 
 @dataclass(frozen=True)
 class Measurement:

--- a/benchmarks/analysis/analyze_results.py
+++ b/benchmarks/analysis/analyze_results.py
@@ -1,4 +1,5 @@
 import csv
+import json
 import math
 from collections import defaultdict
 from dataclasses import dataclass
@@ -8,6 +9,13 @@ from statistics import fmean, median, pstdev
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 RESULTS_DIRECTORY = PROJECT_ROOT / "benchmarks" / "results"
+
+CONFIG_PATH = (
+    PROJECT_ROOT
+    / "benchmarks"
+    / "config"
+    / "benchmark_config.json"
+)
 
 RESULT_FILES = [
     "pure_python_results.csv",
@@ -22,7 +30,144 @@ class Measurement:
     algorithm: str
     resolution: str
     trial: int
+    frame_index: int
     processing_time_ms: float
+
+def load_benchmark_expectations() -> tuple[
+    int,
+    int,
+    set[str],
+    set[str],
+]:
+    with CONFIG_PATH.open(
+        "r",
+        encoding="utf-8",
+    ) as config_file:
+        config = json.load(config_file)
+
+    measured_frames = int(
+        config["benchmark"]["measured_frames"]
+    )
+    trials = int(config["benchmark"]["trials"])
+
+    algorithms = {
+        algorithm["name"]
+        for algorithm in config["algorithms"]
+    }
+
+    resolutions = {
+        f'{resolution["width"]}x{resolution["height"]}'
+        for resolution in config["resolutions"]
+    }
+
+    if measured_frames <= 0 or trials <= 0:
+        raise ValueError(
+            "Measured frame and trial counts must be positive."
+        )
+
+    return (
+        measured_frames,
+        trials,
+        algorithms,
+        resolutions,
+    )
+
+
+def validate_measurements(
+    measurements: list[Measurement],
+) -> None:
+    (
+        measured_frames,
+        trial_count,
+        algorithms,
+        resolutions,
+    ) = load_benchmark_expectations()
+
+    architectures = set(RESULT_FILES.values())
+    expected_trials = set(range(1, trial_count + 1))
+    expected_frames = set(
+        range(1, measured_frames + 1)
+    )
+
+    groups = defaultdict(list)
+
+    for measurement in measurements:
+        if measurement.architecture not in architectures:
+            raise ValueError(
+                "Unexpected architecture: "
+                f"{measurement.architecture}"
+            )
+
+        if measurement.algorithm not in algorithms:
+            raise ValueError(
+                "Unexpected algorithm: "
+                f"{measurement.algorithm}"
+            )
+
+        if measurement.resolution not in resolutions:
+            raise ValueError(
+                "Unexpected resolution: "
+                f"{measurement.resolution}"
+            )
+
+        if measurement.trial not in expected_trials:
+            raise ValueError(
+                "Unexpected trial number: "
+                f"{measurement.trial}"
+            )
+
+        key = (
+            measurement.architecture,
+            measurement.algorithm,
+            measurement.resolution,
+            measurement.trial,
+        )
+        groups[key].append(measurement.frame_index)
+
+    expected_groups = {
+        (architecture, algorithm, resolution, trial)
+        for architecture in architectures
+        for algorithm in algorithms
+        for resolution in resolutions
+        for trial in expected_trials
+    }
+
+    missing_groups = expected_groups - set(groups)
+    unexpected_groups = set(groups) - expected_groups
+
+    if missing_groups:
+        raise ValueError(
+            "Missing benchmark groups: "
+            f"{sorted(missing_groups)[:5]}"
+        )
+
+    if unexpected_groups:
+        raise ValueError(
+            "Unexpected benchmark groups: "
+            f"{sorted(unexpected_groups)[:5]}"
+        )
+
+    for key, frame_indices in groups.items():
+        unique_frames = set(frame_indices)
+
+        if len(unique_frames) != len(frame_indices):
+            raise ValueError(
+                f"Duplicate frame indices in group {key}."
+            )
+
+        if unique_frames != expected_frames:
+            missing_frames = (
+                expected_frames - unique_frames
+            )
+            extra_frames = (
+                unique_frames - expected_frames
+            )
+
+            raise ValueError(
+                f"Invalid frames in group {key}. "
+                f"Missing: {sorted(missing_frames)[:5]}, "
+                f"extra: {sorted(extra_frames)[:5]}"
+            )
 
 
 def calculate_percentile(
@@ -85,7 +230,7 @@ def load_measurements() -> list[Measurement]:
         "processing_time_ms",
     }
 
-    for file_name in RESULT_FILES:
+    for file_name, expected_architecture in RESULT_FILES.items():
         result_path = RESULTS_DIRECTORY / file_name
 
         if not result_path.is_file():
@@ -116,6 +261,14 @@ def load_measurements() -> list[Measurement]:
                 )
 
             for row in reader:
+                architecture = row["architecture"].strip()
+
+                if architecture != expected_architecture:
+                    raise ValueError(
+                        f"Unexpected architecture in {result_path}: "
+                        f"expected {expected_architecture}, "
+                        f"received {architecture}"
+                    )
                 processing_time_ms = float(
                     row["processing_time_ms"]
                 )
@@ -132,10 +285,11 @@ def load_measurements() -> list[Measurement]:
 
                 measurements.append(
                     Measurement(
-                        architecture=row["architecture"],
+                        architecture=architecture,
                         algorithm=row["algorithm"],
                         resolution=row["resolution"],
                         trial=int(row["trial"]),
+                        frame_index=int(row["frame_index"]),
                         processing_time_ms=(
                             processing_time_ms
                         ),
@@ -299,6 +453,7 @@ def write_overall_summary(
 
 def main() -> None:
     measurements = load_measurements()
+    validate_measurements(measurements)
 
     trial_summary_path = write_trial_summary(
         measurements

--- a/benchmarks/runners/hybrid_benchmark.py
+++ b/benchmarks/runners/hybrid_benchmark.py
@@ -211,6 +211,8 @@ def run_test_case(
                 interpolation=cv2.INTER_LINEAR,
             )
 
+            processed_frame = None
+
             start_time = perf_counter_ns()
 
             processed_frame = visionlab_cpp.process_frame(

--- a/benchmarks/runners/pure_cpp_benchmark.cpp
+++ b/benchmarks/runners/pure_cpp_benchmark.cpp
@@ -19,377 +19,351 @@
 #include <string>
 #include <vector>
 
-#ifndef VISIONLAB_PROJECT_ROOT
-#error "VISIONLAB_PROJECT_ROOT is not defined."
+#ifndef VISIONLAB_BENCHMARK_RELEASE
+#define VISIONLAB_BENCHMARK_RELEASE 0
 #endif
 
-namespace
-{
+namespace {
+    namespace fs = std::filesystem;
 
-namespace fs = std::filesystem;
+    struct Resolution {
+        int width;
+        int height;
+    };
 
-struct Resolution
-{
-    int width;
-    int height;
-};
+    struct AlgorithmConfiguration {
+        std::string name;
+        ProcessingAlgorithm algorithm;
+        ProcessingParameters parameters;
+    };
 
-struct AlgorithmConfiguration
-{
-    std::string name;
-    ProcessingAlgorithm algorithm;
-    ProcessingParameters parameters;
-};
+    struct BenchmarkConfiguration {
+        fs::path videoPath;
+        fs::path outputDirectory;
+        int warmupFrames;
+        int measuredFrames;
+        int trials;
+        std::vector<Resolution> resolutions;
+        std::vector<AlgorithmConfiguration> algorithms;
+    };
 
-struct BenchmarkConfiguration
-{
-    fs::path videoPath;
-    fs::path outputDirectory;
-    int warmupFrames;
-    int measuredFrames;
-    int trials;
-    std::vector<Resolution> resolutions;
-    std::vector<AlgorithmConfiguration> algorithms;
-};
+    ProcessingAlgorithm algorithmFromName(
+        const std::string &name
+    ) {
+        if (name == "original") {
+            return ProcessingAlgorithm::Original;
+        }
 
-ProcessingAlgorithm algorithmFromName(
-    const std::string &name
-)
-{
-    if (name == "original")
-    {
-        return ProcessingAlgorithm::Original;
-    }
+        if (name == "gamma_correction") {
+            return ProcessingAlgorithm::GammaCorrection;
+        }
 
-    if (name == "gamma_correction")
-    {
-        return ProcessingAlgorithm::GammaCorrection;
-    }
+        if (name == "histogram_equalization") {
+            return ProcessingAlgorithm::HistogramEqualization;
+        }
 
-    if (name == "histogram_equalization")
-    {
-        return ProcessingAlgorithm::HistogramEqualization;
-    }
+        if (name == "clahe") {
+            return ProcessingAlgorithm::Clahe;
+        }
 
-    if (name == "clahe")
-    {
-        return ProcessingAlgorithm::Clahe;
-    }
-
-    throw std::invalid_argument(
-        "Unsupported algorithm: " + name
-    );
-}
-
-BenchmarkConfiguration loadConfiguration(
-    const fs::path &projectRoot
-)
-{
-    const fs::path configPath =
-        projectRoot
-        / "benchmarks"
-        / "config"
-        / "benchmark_config.json";
-
-    QFile configFile(
-        QString::fromStdString(
-            configPath.generic_string()
-        )
-    );
-
-    if (!configFile.open(QIODevice::ReadOnly))
-    {
-        throw std::runtime_error(
-            "Could not open benchmark configuration: "
-            + configPath.string()
+        throw std::invalid_argument(
+            "Unsupported algorithm: " + name
         );
     }
 
-    QJsonParseError parseError;
+    BenchmarkConfiguration loadConfiguration(
+        const fs::path &projectRoot
+    ) {
+        const fs::path configPath =
+                projectRoot
+                / "benchmarks"
+                / "config"
+                / "benchmark_config.json";
 
-    const QJsonDocument document =
-        QJsonDocument::fromJson(
-            configFile.readAll(),
-            &parseError
+        QFile configFile(
+            QString::fromStdString(
+                configPath.generic_string()
+            )
         );
 
-    if (parseError.error !=
-        QJsonParseError::NoError)
-    {
-        throw std::runtime_error(
-            "Invalid benchmark JSON: "
-            + parseError.errorString().toStdString()
-        );
-    }
-
-    if (!document.isObject())
-    {
-        throw std::runtime_error(
-            "Benchmark configuration must be an object."
-        );
-    }
-
-    const QJsonObject root = document.object();
-    const QJsonObject input =
-        root.value("input").toObject();
-    const QJsonObject benchmark =
-        root.value("benchmark").toObject();
-    const QJsonObject output =
-        root.value("output").toObject();
-
-    BenchmarkConfiguration configuration;
-
-    configuration.videoPath =
-        projectRoot
-        / input.value("video_path")
-              .toString()
-              .toStdString();
-
-    configuration.outputDirectory =
-        projectRoot
-        / output.value("directory")
-              .toString()
-              .toStdString();
-
-    configuration.warmupFrames =
-        benchmark.value("warmup_frames").toInt(-1);
-
-    configuration.measuredFrames =
-        benchmark.value("measured_frames").toInt(-1);
-
-    configuration.trials =
-        benchmark.value("trials").toInt(-1);
-
-    if (configuration.warmupFrames < 0 ||
-        configuration.measuredFrames <= 0 ||
-        configuration.trials <= 0)
-    {
-        throw std::runtime_error(
-            "Invalid benchmark frame or trial counts."
-        );
-    }
-
-    const QJsonArray resolutionArray =
-        root.value("resolutions").toArray();
-
-    for (const QJsonValue &value : resolutionArray)
-    {
-        const QJsonObject object = value.toObject();
-
-        Resolution resolution{
-            object.value("width").toInt(-1),
-            object.value("height").toInt(-1)
-        };
-
-        if (resolution.width <= 0 ||
-            resolution.height <= 0)
-        {
+        if (!configFile.open(QIODevice::ReadOnly)) {
             throw std::runtime_error(
-                "Invalid benchmark resolution."
+                "Could not open benchmark configuration: "
+                + configPath.string()
             );
         }
 
-        configuration.resolutions.push_back(
-            resolution
-        );
-    }
+        QJsonParseError parseError;
 
-    const QJsonArray algorithmArray =
-        root.value("algorithms").toArray();
+        const QJsonDocument document =
+                QJsonDocument::fromJson(
+                    configFile.readAll(),
+                    &parseError
+                );
 
-    for (const QJsonValue &value : algorithmArray)
-    {
-        const QJsonObject object = value.toObject();
-        const QJsonObject parameters =
-            object.value("parameters").toObject();
+        if (parseError.error !=
+            QJsonParseError::NoError) {
+            throw std::runtime_error(
+                "Invalid benchmark JSON: "
+                + parseError.errorString().toStdString()
+            );
+        }
 
-        AlgorithmConfiguration algorithmConfig;
+        if (!document.isObject()) {
+            throw std::runtime_error(
+                "Benchmark configuration must be an object."
+            );
+        }
 
-        algorithmConfig.name =
-            object.value("name")
+        const QJsonObject root = document.object();
+        const QJsonObject input =
+                root.value("input").toObject();
+        const QJsonObject benchmark =
+                root.value("benchmark").toObject();
+        const QJsonObject output =
+                root.value("output").toObject();
+
+        BenchmarkConfiguration configuration;
+
+        configuration.videoPath =
+                projectRoot
+                / input.value("video_path")
                 .toString()
                 .toStdString();
 
-        algorithmConfig.algorithm =
-            algorithmFromName(
-                algorithmConfig.name
-            );
+        configuration.outputDirectory =
+                projectRoot
+                / output.value("directory")
+                .toString()
+                .toStdString();
 
-        algorithmConfig.parameters.gammaValue =
-            parameters.value("gamma_value")
-                .toDouble(0.6);
+        configuration.warmupFrames =
+                benchmark.value("warmup_frames").toInt(-1);
 
-        algorithmConfig.parameters.claheClipLimit =
-            parameters.value("clip_limit")
-                .toDouble(4.0);
+        configuration.measuredFrames =
+                benchmark.value("measured_frames").toInt(-1);
 
-        algorithmConfig.parameters.claheGridSize =
-            parameters.value("grid_size")
-                .toInt(8);
+        configuration.trials =
+                benchmark.value("trials").toInt(-1);
 
-        configuration.algorithms.push_back(
-            algorithmConfig
-        );
-    }
-
-    if (configuration.resolutions.empty() ||
-        configuration.algorithms.empty())
-    {
-        throw std::runtime_error(
-            "Benchmark configuration is incomplete."
-        );
-    }
-
-    return configuration;
-}
-
-cv::Mat readFrame(cv::VideoCapture &capture)
-{
-    cv::Mat frame;
-
-    if (capture.read(frame) && !frame.empty())
-    {
-        return frame;
-    }
-
-    capture.set(cv::CAP_PROP_POS_FRAMES, 0);
-
-    if (!capture.read(frame) || frame.empty())
-    {
-        throw std::runtime_error(
-            "Could not read a frame from the video."
-        );
-    }
-
-    return frame;
-}
-
-void runTestCase(
-    std::ofstream &output,
-    const ImageProcess &processor,
-    const BenchmarkConfiguration &configuration,
-    const Resolution &resolution,
-    const AlgorithmConfiguration &algorithm,
-    int trial
-)
-{
-    cv::VideoCapture capture(
-        configuration.videoPath.string()
-    );
-
-    if (!capture.isOpened())
-    {
-        throw std::runtime_error(
-            "Could not open benchmark video: "
-            + configuration.videoPath.string()
-        );
-    }
-
-    for (int index = 0;
-         index < configuration.warmupFrames;
-         ++index)
-    {
-        const cv::Mat frame = readFrame(capture);
-
-        cv::Mat resizedFrame;
-        cv::resize(
-            frame,
-            resizedFrame,
-            cv::Size(
-                resolution.width,
-                resolution.height
-            ),
-            0.0,
-            0.0,
-            cv::INTER_LINEAR
-        );
-
-        cv::Mat processedFrame;
-
-        processor.process(
-            resizedFrame,
-            processedFrame,
-            algorithm.algorithm,
-            algorithm.parameters
-        );
-    }
-
-    for (int frameIndex = 1;
-         frameIndex <= configuration.measuredFrames;
-         ++frameIndex)
-    {
-        const cv::Mat frame = readFrame(capture);
-
-        cv::Mat resizedFrame;
-        cv::resize(
-            frame,
-            resizedFrame,
-            cv::Size(
-                resolution.width,
-                resolution.height
-            ),
-            0.0,
-            0.0,
-            cv::INTER_LINEAR
-        );
-
-        cv::Mat processedFrame;
-
-        const auto startTime =
-            std::chrono::steady_clock::now();
-
-        processor.process(
-            resizedFrame,
-            processedFrame,
-            algorithm.algorithm,
-            algorithm.parameters
-        );
-
-        const auto endTime =
-            std::chrono::steady_clock::now();
-
-        if (processedFrame.empty())
-        {
+        if (configuration.warmupFrames < 0 ||
+            configuration.measuredFrames <= 0 ||
+            configuration.trials <= 0) {
             throw std::runtime_error(
-                "The algorithm produced an empty frame."
+                "Invalid benchmark frame or trial counts."
             );
         }
 
-        const double processTimeMs =
-            std::chrono::duration<
-                double,
-                std::milli
-            >(endTime - startTime).count();
+        const QJsonArray resolutionArray =
+                root.value("resolutions").toArray();
 
-        output
-            << "pure_cpp,"
-            << algorithm.name << ','
-            << resolution.width << 'x'
-            << resolution.height << ','
-            << trial << ','
-            << frameIndex << ','
-            << processTimeMs
-            << '\n';
+        for (const QJsonValue &value: resolutionArray) {
+            const QJsonObject object = value.toObject();
+
+            Resolution resolution{
+                object.value("width").toInt(-1),
+                object.value("height").toInt(-1)
+            };
+
+            if (resolution.width <= 0 ||
+                resolution.height <= 0) {
+                throw std::runtime_error(
+                    "Invalid benchmark resolution."
+                );
+            }
+
+            configuration.resolutions.push_back(
+                resolution
+            );
+        }
+
+        const QJsonArray algorithmArray =
+                root.value("algorithms").toArray();
+
+        for (const QJsonValue &value: algorithmArray) {
+            const QJsonObject object = value.toObject();
+            const QJsonObject parameters =
+                    object.value("parameters").toObject();
+
+            AlgorithmConfiguration algorithmConfig;
+
+            algorithmConfig.name =
+                    object.value("name")
+                    .toString()
+                    .toStdString();
+
+            algorithmConfig.algorithm =
+                    algorithmFromName(
+                        algorithmConfig.name
+                    );
+
+            algorithmConfig.parameters.gammaValue =
+                    parameters.value("gamma_value")
+                    .toDouble(0.6);
+
+            algorithmConfig.parameters.claheClipLimit =
+                    parameters.value("clip_limit")
+                    .toDouble(4.0);
+
+            algorithmConfig.parameters.claheGridSize =
+                    parameters.value("grid_size")
+                    .toInt(8);
+
+            configuration.algorithms.push_back(
+                algorithmConfig
+            );
+        }
+
+        if (configuration.resolutions.empty() ||
+            configuration.algorithms.empty()) {
+            throw std::runtime_error(
+                "Benchmark configuration is incomplete."
+            );
+        }
+
+        return configuration;
     }
-}
 
+    cv::Mat readFrame(cv::VideoCapture &capture) {
+        cv::Mat frame;
+
+        if (capture.read(frame) && !frame.empty()) {
+            return frame;
+        }
+
+        capture.set(cv::CAP_PROP_POS_FRAMES, 0);
+
+        if (!capture.read(frame) || frame.empty()) {
+            throw std::runtime_error(
+                "Could not read a frame from the video."
+            );
+        }
+
+        return frame;
+    }
+
+    void runTestCase(
+        std::ofstream &output,
+        const ImageProcess &processor,
+        const BenchmarkConfiguration &configuration,
+        const Resolution &resolution,
+        const AlgorithmConfiguration &algorithm,
+        int trial
+    ) {
+        cv::VideoCapture capture(
+            configuration.videoPath.string()
+        );
+
+        if (!capture.isOpened()) {
+            throw std::runtime_error(
+                "Could not open benchmark video: "
+                + configuration.videoPath.string()
+            );
+        }
+
+        for (int index = 0;
+             index < configuration.warmupFrames;
+             ++index) {
+            const cv::Mat frame = readFrame(capture);
+
+            cv::Mat resizedFrame;
+            cv::resize(
+                frame,
+                resizedFrame,
+                cv::Size(
+                    resolution.width,
+                    resolution.height
+                ),
+                0.0,
+                0.0,
+                cv::INTER_LINEAR
+            );
+
+            cv::Mat processedFrame;
+
+            processor.process(
+                resizedFrame,
+                processedFrame,
+                algorithm.algorithm,
+                algorithm.parameters
+            );
+        }
+
+        for (int frameIndex = 1;
+             frameIndex <= configuration.measuredFrames;
+             ++frameIndex) {
+            const cv::Mat frame = readFrame(capture);
+
+            cv::Mat resizedFrame;
+            cv::resize(
+                frame,
+                resizedFrame,
+                cv::Size(
+                    resolution.width,
+                    resolution.height
+                ),
+                0.0,
+                0.0,
+                cv::INTER_LINEAR
+            );
+
+            cv::Mat processedFrame;
+
+            const auto startTime =
+                    std::chrono::steady_clock::now();
+
+            processor.process(
+                resizedFrame,
+                processedFrame,
+                algorithm.algorithm,
+                algorithm.parameters
+            );
+
+            const auto endTime =
+                    std::chrono::steady_clock::now();
+
+            if (processedFrame.empty()) {
+                throw std::runtime_error(
+                    "The algorithm produced an empty frame."
+                );
+            }
+
+            const double processTimeMs =
+                    std::chrono::duration<
+                        double,
+                        std::milli
+                    >(endTime - startTime).count();
+
+            output
+                    << "pure_cpp,"
+                    << algorithm.name << ','
+                    << resolution.width << 'x'
+                    << resolution.height << ','
+                    << trial << ','
+                    << frameIndex << ','
+                    << processTimeMs
+                    << '\n';
+        }
+    }
 } // namespace
 
-int main()
-{
-    try
-    {
+int main() {
+#if !VISIONLAB_BENCHMARK_RELEASE
+    std::cerr
+            << "VisionLabCppBenchmark must be run in Release mode.\n";
+    return 1;
+#endif
+    try {
         const fs::path projectRoot =
-            fs::path(VISIONLAB_PROJECT_ROOT)
+                fs::path(VISIONLAB_PROJECT_ROOT)
                 .lexically_normal();
 
         const BenchmarkConfiguration configuration =
-            loadConfiguration(projectRoot);
+                loadConfiguration(projectRoot);
 
         if (!fs::is_regular_file(
-                configuration.videoPath
-            ))
-        {
+            configuration.videoPath
+        )) {
             throw std::runtime_error(
                 "Benchmark video was not found: "
                 + configuration.videoPath.string()
@@ -401,13 +375,12 @@ int main()
         );
 
         const fs::path outputPath =
-            configuration.outputDirectory
-            / "pure_cpp_results.csv";
+                configuration.outputDirectory
+                / "pure_cpp_results.csv";
 
         std::ofstream output(outputPath);
 
-        if (!output.is_open())
-        {
+        if (!output.is_open()) {
             throw std::runtime_error(
                 "Could not create result file: "
                 + outputPath.string()
@@ -415,37 +388,34 @@ int main()
         }
 
         output
-            << "architecture,algorithm,resolution,"
-            << "trial,frame_index,processing_time_ms\n";
+                << "architecture,algorithm,resolution,"
+                << "trial,frame_index,processing_time_ms\n";
 
         output
-            << std::fixed
-            << std::setprecision(6);
+                << std::fixed
+                << std::setprecision(6);
 
         const ImageProcess processor;
 
-        for (const Resolution &resolution :
-             configuration.resolutions)
-        {
-            for (const AlgorithmConfiguration &algorithm :
-                 configuration.algorithms)
-            {
+        for (const Resolution &resolution:
+             configuration.resolutions) {
+            for (const AlgorithmConfiguration &algorithm:
+                 configuration.algorithms) {
                 for (int trial = 1;
                      trial <= configuration.trials;
-                     ++trial)
-                {
+                     ++trial) {
                     std::cout
-                        << "Pure C++ | "
-                        << algorithm.name
-                        << " | "
-                        << resolution.width
-                        << 'x'
-                        << resolution.height
-                        << " | trial "
-                        << trial
-                        << '/'
-                        << configuration.trials
-                        << '\n';
+                            << "Pure C++ | "
+                            << algorithm.name
+                            << " | "
+                            << resolution.width
+                            << 'x'
+                            << resolution.height
+                            << " | trial "
+                            << trial
+                            << '/'
+                            << configuration.trials
+                            << '\n';
 
                     runTestCase(
                         output,
@@ -462,18 +432,16 @@ int main()
         }
 
         std::cout
-            << "Benchmark completed: "
-            << outputPath
-            << '\n';
+                << "Benchmark completed: "
+                << outputPath
+                << '\n';
 
         return 0;
-    }
-    catch (const std::exception &exception)
-    {
+    } catch (const std::exception &exception) {
         std::cerr
-            << "Benchmark failed: "
-            << exception.what()
-            << '\n';
+                << "Benchmark failed: "
+                << exception.what()
+                << '\n';
 
         return 1;
     }

--- a/benchmarks/runners/pure_cpp_benchmark.cpp
+++ b/benchmarks/runners/pure_cpp_benchmark.cpp
@@ -19,6 +19,10 @@
 #include <string>
 #include <vector>
 
+#ifndef VISIONLAB_PROJECT_ROOT
+#error "VISIONLAB_PROJECT_ROOT is not defined."
+#endif
+
 #ifndef VISIONLAB_BENCHMARK_RELEASE
 #define VISIONLAB_BENCHMARK_RELEASE 0
 #endif

--- a/benchmarks/runners/pure_python_benchmark.py
+++ b/benchmarks/runners/pure_python_benchmark.py
@@ -122,6 +122,8 @@ def run_test_case(
                 interpolation=cv2.INTER_LINEAR,
             )
 
+            processed_frame = None
+
             start_time = perf_counter_ns()
 
             processed_frame = processor.process(

--- a/cpp-opencv-core/CMakeLists.txt
+++ b/cpp-opencv-core/CMakeLists.txt
@@ -73,6 +73,7 @@ target_compile_definitions(
     PRIVATE
 
     VISIONLAB_PROJECT_ROOT="${CMAKE_CURRENT_SOURCE_DIR}/.."
+    VISIONLAB_BENCHMARK_RELEASE=$<IF:$<CONFIG:Release>,1,0>
 )
 
 if(WIN32)


### PR DESCRIPTION
This PR tightens benchmark reproducibility by enforcing consistent build/runtime conditions and adding stronger post-run integrity validation so results are comparable across Pure Python, Hybrid, and Pure C++ implementations.

Changes:

- Add a build-config compile definition and a runtime gate to prevent running the Pure C++ benchmark outside the intended configuration.
- Reduce timing contamination in Python benchmark loops by releasing the previous processed frame before starting the timer.
- Extend the results analyzer to validate CSV integrity against the shared benchmark configuration (expected groups, frame indices, and architecture labels), and expand the reproducibility guide.