### PR TITLE
feat: add cross-architecture output equivalence validation

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -148,6 +148,10 @@ mean absolute error = 0
 maximum absolute error = 0
 ```
 
+The validation script also verifies that the active environment
+and `pure-python/.venv` use identical Python, NumPy, and OpenCV
+versions before running comparisons.
+
 ### Linux and macOS
 
 ```bash

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -124,11 +124,91 @@ cmake \
 
 The benchmark executable must not be run from a Debug build. Debug execution is intentionally rejected by the application.
 
-## 5. Run benchmarks on Linux and macOS
+## 5. Validate output equivalence
+
+Output equivalence must be validated before running the official performance benchmarks.
+
+The validation script compares the Pure Python implementation against the shared C++ `ImageProcess` core used by both the Hybrid and Pure C++ implementations.
+
+It tests:
+
+* Five deterministic frames distributed across the benchmark video
+* Every algorithm defined in `benchmark_config.json`
+* Every configured resolution
+* Output shape and data type
+* Mean absolute error
+* Maximum absolute error
+* PSNR
+* Exact pixel equality
+
+The default validation requires exact pixel-level equality:
+
+```text
+mean absolute error = 0
+maximum absolute error = 0
+```
+
+### Linux and macOS
+
+```bash
+source hybrid-python-cpp/.venv/bin/activate
+
+python benchmarks/validation/validate_output_equivalence.py
+
+deactivate
+```
+
+### Windows PowerShell
+
+```powershell
+.\hybrid-python-cpp\.venv\Scripts\Activate.ps1
+
+python benchmarks\validation\validate_output_equivalence.py
+
+deactivate
+```
+
+### Windows Git Bash
+
+```bash
+source hybrid-python-cpp/.venv/Scripts/activate
+
+python benchmarks/validation/validate_output_equivalence.py
+
+deactivate
+```
+
+If the compiled C++ module is not discovered automatically, set `VISIONLAB_CPP_MODULE_DIR` to the directory containing `visionlab_cpp` before running the validation.
+
+A successful default validation finishes with:
+
+```text
+Output equivalence passed for 60 comparison(s).
+```
+
+The number of comparisons is calculated as:
+
+```text
+5 frames × 3 resolutions × 4 algorithms
+= 60 comparisons
+```
+
+Detailed results are written to:
+
+```text
+benchmarks/results/output_equivalence_results.csv
+```
+
+This generated CSV is ignored by Git and should not be committed.
+
+Do not increase the error tolerances unless the numerical differences have been investigated and scientifically justified.
+
+
+## 6. Run benchmarks on Linux and macOS
 
 Run the implementations in the following order.
 
-### 5.1. Pure Python
+### 6.1. Pure Python
 
 ```bash
 source pure-python/.venv/bin/activate
@@ -138,7 +218,7 @@ python benchmarks/runners/pure_python_benchmark.py
 deactivate
 ```
 
-### 5.2. Hybrid Python+C++
+### 6.2. Hybrid Python+C++
 
 Activate the Hybrid environment:
 
@@ -166,7 +246,7 @@ python benchmarks/runners/hybrid_benchmark.py
 deactivate
 ```
 
-### 5.3. Pure C++
+### 6.3. Pure C++
 
 For a single-config build:
 
@@ -180,7 +260,7 @@ For a multi-config build:
 ./cpp-opencv-core/build/Release/VisionLabCppBenchmark
 ```
 
-## 6. Windows setup and execution
+## 7. Windows setup and execution
 
 The recommended Windows configuration is a 64-bit MSVC kit with Release selected in Qt Creator.
 
@@ -192,7 +272,7 @@ build/Desktop_Qt_6_11_1_MSVC2022_64bit-Release
 
 Use the actual Release directory generated on your computer.
 
-### 6.1. PowerShell environments
+### 7.1. PowerShell environments
 
 If PowerShell prevents virtual-environment activation, allow scripts for the current terminal:
 
@@ -224,7 +304,7 @@ python -m pip install -r hybrid-python-cpp\requirements.txt
 deactivate
 ```
 
-### 6.2. Build with Qt Creator
+### 7.2. Build with Qt Creator
 
 For both `hybrid-python-cpp` and `cpp-opencv-core`:
 
@@ -236,7 +316,7 @@ For both `hybrid-python-cpp` and `cpp-opencv-core`:
 
 Do not use a Debug binary for official measurements.
 
-### 6.3. Run Pure Python in PowerShell
+### 7.3. Run Pure Python in PowerShell
 
 ```powershell
 .\pure-python\.venv\Scripts\Activate.ps1
@@ -246,7 +326,7 @@ python benchmarks\runners\pure_python_benchmark.py
 deactivate
 ```
 
-### 6.4. Locate and run the Hybrid module
+### 7.4. Locate and run the Hybrid module
 
 Locate the compiled module:
 
@@ -268,7 +348,7 @@ deactivate
 
 Replace `YOUR_RELEASE_DIRECTORY` with the directory reported by Qt Creator or the preceding search command.
 
-### 6.5. Locate and run the Pure C++ benchmark
+### 7.5. Locate and run the Pure C++ benchmark
 
 Locate the executable:
 
@@ -290,7 +370,7 @@ VisionLabCppBenchmark must be run in Release mode.
 
 Switch to the Release build before continuing.
 
-### 6.6. Git Bash on Windows
+### 7.6. Git Bash on Windows
 
 Run Pure Python:
 
@@ -320,7 +400,7 @@ Run Pure C++:
 ./cpp-opencv-core/build/YOUR_RELEASE_DIRECTORY/VisionLabCppBenchmark.exe
 ```
 
-## 7. Analyze the results
+## 8. Analyze the results
 
 Run the analyzer after all three benchmark runners finish successfully:
 
@@ -340,7 +420,7 @@ The analyzer validates the result files against the current benchmark configurat
 
 If the configuration changes, rerun all three implementations before analyzing the results.
 
-## 8. Expected output files
+## 9. Expected output files
 
 After a successful benchmark and analysis run, `benchmarks/results/` must contain:
 
@@ -363,7 +443,7 @@ With the default configuration, each architecture produces:
 
 Warm-up frames are not written to the result files.
 
-## 9. Fair-comparison requirements
+## 10. Fair-comparison requirements
 
 For scientifically meaningful results:
 

--- a/benchmarks/validation/validate_output_equivalence.py
+++ b/benchmarks/validation/validate_output_equivalence.py
@@ -550,7 +550,7 @@ def main() -> int:
                         f"{status} | {algorithm_name} | "
                         f"{resolution_name} | "
                         f"frame {frame_index} | "
-                        f"MAE {metrics.mean_absolute_error:.6f} | "
+                        f"MAE {metrics.mean_absolute_error:.12g} | "
                         "max error "
                         f"{metrics.maximum_absolute_error}"
                     )

--- a/benchmarks/validation/validate_output_equivalence.py
+++ b/benchmarks/validation/validate_output_equivalence.py
@@ -81,12 +81,19 @@ def read_runtime_dependency_versions(
             "}))"
         ),
     ]
-    process = subprocess.run(
-        command,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        process = subprocess.run(
+            command,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as error:
+        stderr_output = (error.stderr or "").strip()
+        raise RuntimeError(
+            "Could not read runtime dependencies from "
+            f"{python_executable}: {stderr_output or error}"
+        ) from error
 
     return json.loads(process.stdout)
 

--- a/benchmarks/validation/validate_output_equivalence.py
+++ b/benchmarks/validation/validate_output_equivalence.py
@@ -252,7 +252,10 @@ def read_frame_at(
     capture: cv2.VideoCapture,
     frame_index: int,
 ) -> np.ndarray:
-    capture.set(cv2.CAP_PROP_POS_FRAMES, frame_index)
+    if not capture.set(cv2.CAP_PROP_POS_FRAMES, frame_index):
+        raise RuntimeError(
+            f"Could not seek to video frame {frame_index}."
+        )
     frame_received, frame = capture.read()
 
     if not frame_received or frame is None or frame.size == 0:

--- a/benchmarks/validation/validate_output_equivalence.py
+++ b/benchmarks/validation/validate_output_equivalence.py
@@ -95,7 +95,13 @@ def read_runtime_dependency_versions(
             f"{python_executable}: {stderr_output or error}"
         ) from error
 
-    return json.loads(process.stdout)
+    try:
+        return json.loads(process.stdout)
+    except json.JSONDecodeError as error:
+        raise RuntimeError(
+            "Could not parse runtime dependencies from "
+            f"{python_executable}: {process.stdout.strip()}"
+        ) from error
 
 
 def validate_runtime_dependencies_match() -> None:

--- a/benchmarks/validation/validate_output_equivalence.py
+++ b/benchmarks/validation/validate_output_equivalence.py
@@ -3,6 +3,7 @@ import csv
 import json
 import math
 import os
+import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -46,6 +47,82 @@ class EquivalenceMetrics:
     maximum_absolute_error: int
     psnr: float
     exact_match: bool
+
+
+def get_pure_python_interpreter_path() -> Path:
+    interpreter_path = (
+        PURE_PYTHON_DIRECTORY / ".venv" / "Scripts" / "python.exe"
+        if os.name == "nt"
+        else PURE_PYTHON_DIRECTORY / ".venv" / "bin" / "python"
+    )
+
+    if not interpreter_path.is_file():
+        raise FileNotFoundError(
+            "Pure Python virtual environment interpreter was "
+            "not found. Expected: "
+            f"{interpreter_path}"
+        )
+
+    return interpreter_path
+
+
+def read_runtime_dependency_versions(
+    python_executable: Path,
+) -> dict[str, str]:
+    command = [
+        str(python_executable),
+        "-c",
+        (
+            "import cv2, json, numpy as np, sys; "
+            "print(json.dumps({"
+            "'python': sys.version.split()[0], "
+            "'numpy': np.__version__, "
+            "'opencv': cv2.__version__"
+            "}))"
+        ),
+    ]
+    process = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    return json.loads(process.stdout)
+
+
+def validate_runtime_dependencies_match() -> None:
+    current_versions = {
+        "python": sys.version.split()[0],
+        "numpy": np.__version__,
+        "opencv": cv2.__version__,
+    }
+    pure_python_versions = read_runtime_dependency_versions(
+        get_pure_python_interpreter_path()
+    )
+    mismatches = [
+        dependency_name
+        for dependency_name in current_versions
+        if current_versions[dependency_name]
+        != pure_python_versions.get(dependency_name)
+    ]
+
+    if mismatches:
+        mismatch_message = ", ".join(
+            (
+                f"{dependency_name} "
+                f"(hybrid={current_versions[dependency_name]}, "
+                "pure_python="
+                f"{pure_python_versions.get(dependency_name)})"
+            )
+            for dependency_name in mismatches
+        )
+        raise RuntimeError(
+            "Output equivalence validation requires matching "
+            "runtime dependencies between the active environment "
+            "and pure-python/.venv. Mismatches: "
+            f"{mismatch_message}"
+        )
 
 
 def parse_arguments() -> argparse.Namespace:
@@ -384,6 +461,7 @@ def format_psnr(psnr: float) -> str:
 def main() -> int:
     arguments = parse_arguments()
     config = load_config()
+    validate_runtime_dependencies_match()
     visionlab_cpp = import_cpp_module()
 
     cpp_algorithms = {

--- a/benchmarks/validation/validate_output_equivalence.py
+++ b/benchmarks/validation/validate_output_equivalence.py
@@ -1,0 +1,602 @@
+import argparse
+import csv
+import json
+import math
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+PURE_PYTHON_DIRECTORY = PROJECT_ROOT / "pure-python"
+HYBRID_PROJECT_DIRECTORY = PROJECT_ROOT / "hybrid-python-cpp"
+CONFIG_PATH = (
+    PROJECT_ROOT
+    / "benchmarks"
+    / "config"
+    / "benchmark_config.json"
+)
+
+DLL_DIRECTORY_HANDLES = []
+
+sys.path.insert(0, str(PURE_PYTHON_DIRECTORY))
+
+from image_process import (  # noqa: E402
+    ImageProcess,
+    ProcessingAlgorithm,
+    ProcessingParameters,
+)
+
+
+PURE_PYTHON_ALGORITHMS = {
+    "original": ProcessingAlgorithm.ORIGINAL,
+    "gamma_correction": ProcessingAlgorithm.GAMMA,
+    "histogram_equalization": ProcessingAlgorithm.HISTOGRAM,
+    "clahe": ProcessingAlgorithm.CLAHE,
+}
+
+
+@dataclass(frozen=True)
+class EquivalenceMetrics:
+    mean_absolute_error: float
+    maximum_absolute_error: int
+    psnr: float
+    exact_match: bool
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate pixel-level output equivalence between "
+            "the Pure Python implementation and the shared "
+            "C++ processing core."
+        )
+    )
+    parser.add_argument(
+        "--sample-count",
+        type=int,
+        default=5,
+        help=(
+            "Number of deterministic video frames to validate "
+            "across the full video. Default: 5."
+        ),
+    )
+    parser.add_argument(
+        "--max-mae",
+        type=float,
+        default=0.0,
+        help=(
+            "Maximum accepted mean absolute error. "
+            "Default: 0.0."
+        ),
+    )
+    parser.add_argument(
+        "--max-absolute-error",
+        type=int,
+        default=0,
+        help=(
+            "Maximum accepted per-channel absolute error. "
+            "Default: 0."
+        ),
+    )
+
+    arguments = parser.parse_args()
+
+    if arguments.sample_count <= 0:
+        parser.error("--sample-count must be greater than zero.")
+
+    if not math.isfinite(arguments.max_mae):
+        parser.error("--max-mae must be finite.")
+
+    if arguments.max_mae < 0.0:
+        parser.error("--max-mae cannot be negative.")
+
+    if arguments.max_absolute_error < 0:
+        parser.error(
+            "--max-absolute-error cannot be negative."
+        )
+
+    return arguments
+
+
+def load_config() -> dict:
+    with CONFIG_PATH.open(
+        "r",
+        encoding="utf-8",
+    ) as config_file:
+        return json.load(config_file)
+
+
+def is_release_candidate(
+    candidate: Path,
+    build_directory: Path,
+) -> bool:
+    if "release" in str(candidate.parent).lower():
+        return True
+
+    cache_path = build_directory / "CMakeCache.txt"
+
+    if not cache_path.is_file():
+        return False
+
+    with cache_path.open(
+        "r",
+        encoding="utf-8",
+    ) as cache_file:
+        for line in cache_file:
+            if line.startswith("CMAKE_BUILD_TYPE:STRING="):
+                build_type = line.removeprefix(
+                    "CMAKE_BUILD_TYPE:STRING="
+                ).strip()
+
+                return build_type.lower() == "release"
+
+    return False
+
+
+def find_cpp_module_directory() -> Path:
+    configured_directory = os.getenv(
+        "VISIONLAB_CPP_MODULE_DIR"
+    )
+
+    if configured_directory:
+        module_directory = Path(
+            configured_directory
+        ).resolve()
+
+        if not module_directory.is_dir():
+            raise FileNotFoundError(
+                "VISIONLAB_CPP_MODULE_DIR is not a directory: "
+                f"{module_directory}"
+            )
+
+        configured_candidates = [
+            candidate
+            for pattern in (
+                "visionlab_cpp*.pyd",
+                "visionlab_cpp*.so",
+            )
+            for candidate in module_directory.glob(pattern)
+        ]
+
+        if not configured_candidates:
+            raise FileNotFoundError(
+                "The configured directory does not contain "
+                "a visionlab_cpp module: "
+                f"{module_directory}"
+            )
+
+        return module_directory
+
+    build_directory = HYBRID_PROJECT_DIRECTORY / "build"
+    candidates = []
+
+    for pattern in (
+        "visionlab_cpp*.pyd",
+        "visionlab_cpp*.so",
+    ):
+        candidates.extend(build_directory.rglob(pattern))
+
+    release_candidates = [
+        candidate
+        for candidate in candidates
+        if is_release_candidate(
+            candidate,
+            build_directory,
+        )
+    ]
+
+    if not release_candidates:
+        raise FileNotFoundError(
+            "A Release build of visionlab_cpp was not found. "
+            "Build the Hybrid project in Release mode or set "
+            "VISIONLAB_CPP_MODULE_DIR."
+        )
+
+    newest_module = max(
+        release_candidates,
+        key=lambda path: path.stat().st_mtime,
+    )
+
+    return newest_module.parent
+
+
+def import_cpp_module():
+    module_directory = find_cpp_module_directory()
+    sys.path.insert(0, str(module_directory))
+
+    if os.name == "nt" and hasattr(
+        os,
+        "add_dll_directory",
+    ):
+        DLL_DIRECTORY_HANDLES.append(
+            os.add_dll_directory(str(module_directory))
+        )
+
+    import visionlab_cpp  # noqa: PLC0415
+
+    return visionlab_cpp
+
+
+def choose_frame_indices(
+    frame_count: int,
+    sample_count: int,
+) -> list[int]:
+    if frame_count <= 0:
+        raise ValueError(
+            "The benchmark video reports no readable frames."
+        )
+
+    selected_count = min(frame_count, sample_count)
+
+    if selected_count == 1:
+        return [0]
+
+    indices = {
+        round(
+            sample_index
+            * (frame_count - 1)
+            / (selected_count - 1)
+        )
+        for sample_index in range(selected_count)
+    }
+
+    return sorted(indices)
+
+
+def read_frame_at(
+    capture: cv2.VideoCapture,
+    frame_index: int,
+) -> np.ndarray:
+    capture.set(cv2.CAP_PROP_POS_FRAMES, frame_index)
+    frame_received, frame = capture.read()
+
+    if not frame_received or frame is None or frame.size == 0:
+        raise RuntimeError(
+            f"Could not read video frame {frame_index}."
+        )
+
+    if (
+        frame.dtype != np.uint8
+        or frame.ndim != 3
+        or frame.shape[2] != 3
+    ):
+        raise ValueError(
+            f"Frame {frame_index} is not an H x W x 3 "
+            "uint8 BGR image."
+        )
+
+    return frame
+
+
+def create_python_parameters(
+    algorithm_config: dict,
+) -> ProcessingParameters:
+    parameters = algorithm_config.get("parameters", {})
+
+    return ProcessingParameters(
+        gamma_value=float(
+            parameters.get("gamma_value", 0.6)
+        ),
+        clahe_clip_limit=float(
+            parameters.get("clip_limit", 4.0)
+        ),
+        clahe_grid_size=int(
+            parameters.get("grid_size", 8)
+        ),
+    )
+
+
+def create_cpp_parameters(
+    algorithm_config: dict,
+) -> tuple[float, float, int]:
+    parameters = algorithm_config.get("parameters", {})
+
+    return (
+        float(parameters.get("gamma_value", 0.6)),
+        float(parameters.get("clip_limit", 4.0)),
+        int(parameters.get("grid_size", 8)),
+    )
+
+
+def validate_output_structure(
+    reference: np.ndarray,
+    comparison: np.ndarray,
+    context: str,
+) -> None:
+    if reference.size == 0 or comparison.size == 0:
+        raise ValueError(
+            f"An empty output was produced for {context}."
+        )
+
+    if reference.shape != comparison.shape:
+        raise ValueError(
+            f"Output shape mismatch for {context}: "
+            f"{reference.shape} != {comparison.shape}"
+        )
+
+    if reference.dtype != comparison.dtype:
+        raise ValueError(
+            f"Output data type mismatch for {context}: "
+            f"{reference.dtype} != {comparison.dtype}"
+        )
+
+    if reference.dtype != np.uint8:
+        raise ValueError(
+            f"Output data type must be uint8 for {context}."
+        )
+
+
+def calculate_metrics(
+    reference: np.ndarray,
+    comparison: np.ndarray,
+) -> EquivalenceMetrics:
+    signed_difference = (
+        reference.astype(np.int16)
+        - comparison.astype(np.int16)
+    )
+    absolute_difference = np.abs(signed_difference)
+
+    mean_absolute_error = float(
+        absolute_difference.mean(dtype=np.float64)
+    )
+    maximum_absolute_error = int(
+        absolute_difference.max()
+    )
+
+    squared_difference = np.square(
+        signed_difference.astype(np.float64)
+    )
+    mean_squared_error = float(
+        squared_difference.mean(dtype=np.float64)
+    )
+
+    psnr = (
+        math.inf
+        if mean_squared_error == 0.0
+        else 10.0
+        * math.log10(
+            (255.0 * 255.0) / mean_squared_error
+        )
+    )
+
+    return EquivalenceMetrics(
+        mean_absolute_error=mean_absolute_error,
+        maximum_absolute_error=maximum_absolute_error,
+        psnr=psnr,
+        exact_match=bool(
+            np.array_equal(reference, comparison)
+        ),
+    )
+
+
+def format_psnr(psnr: float) -> str:
+    return "inf" if math.isinf(psnr) else f"{psnr:.6f}"
+
+
+def main() -> int:
+    arguments = parse_arguments()
+    config = load_config()
+    visionlab_cpp = import_cpp_module()
+
+    cpp_algorithms = {
+        "original": (
+            visionlab_cpp.ProcessingAlgorithm.ORIGINAL
+        ),
+        "gamma_correction": (
+            visionlab_cpp.ProcessingAlgorithm.GAMMA
+        ),
+        "histogram_equalization": (
+            visionlab_cpp.ProcessingAlgorithm.HISTOGRAM
+        ),
+        "clahe": visionlab_cpp.ProcessingAlgorithm.CLAHE,
+    }
+
+    video_path = (
+        PROJECT_ROOT / config["input"]["video_path"]
+    ).resolve()
+
+    if not video_path.is_file():
+        raise FileNotFoundError(
+            f"Benchmark video was not found: {video_path}"
+        )
+
+    output_directory = (
+        PROJECT_ROOT / config["output"]["directory"]
+    ).resolve()
+    output_directory.mkdir(parents=True, exist_ok=True)
+
+    output_path = (
+        output_directory
+        / "output_equivalence_results.csv"
+    )
+
+    capture = cv2.VideoCapture(str(video_path))
+
+    if not capture.isOpened():
+        capture.release()
+        raise RuntimeError(
+            f"Benchmark video could not be opened: {video_path}"
+        )
+
+    frame_count = int(
+        capture.get(cv2.CAP_PROP_FRAME_COUNT)
+    )
+    frame_indices = choose_frame_indices(
+        frame_count,
+        arguments.sample_count,
+    )
+
+    processor = ImageProcess()
+    rows = []
+    failure_count = 0
+
+    try:
+        for frame_index in frame_indices:
+            frame = read_frame_at(capture, frame_index)
+
+            for resolution in config["resolutions"]:
+                width = int(resolution["width"])
+                height = int(resolution["height"])
+                resolution_name = f"{width}x{height}"
+
+                resized_frame = cv2.resize(
+                    frame,
+                    (width, height),
+                    interpolation=cv2.INTER_LINEAR,
+                )
+
+                for algorithm_config in config["algorithms"]:
+                    algorithm_name = algorithm_config["name"]
+
+                    if algorithm_name not in PURE_PYTHON_ALGORITHMS:
+                        raise ValueError(
+                            "Unsupported Pure Python algorithm: "
+                            f"{algorithm_name}"
+                        )
+
+                    if algorithm_name not in cpp_algorithms:
+                        raise ValueError(
+                            "Unsupported C++ algorithm: "
+                            f"{algorithm_name}"
+                        )
+
+                    python_output = processor.process(
+                        resized_frame,
+                        PURE_PYTHON_ALGORITHMS[
+                            algorithm_name
+                        ],
+                        create_python_parameters(
+                            algorithm_config
+                        ),
+                    )
+
+                    (
+                        gamma_value,
+                        clahe_clip_limit,
+                        clahe_grid_size,
+                    ) = create_cpp_parameters(
+                        algorithm_config
+                    )
+
+                    cpp_output = visionlab_cpp.process_frame(
+                        resized_frame,
+                        cpp_algorithms[algorithm_name],
+                        gamma_value=gamma_value,
+                        clahe_clip_limit=clahe_clip_limit,
+                        clahe_grid_size=clahe_grid_size,
+                    )
+
+                    context = (
+                        f"algorithm={algorithm_name}, "
+                        f"resolution={resolution_name}, "
+                        f"frame={frame_index}"
+                    )
+                    validate_output_structure(
+                        python_output,
+                        cpp_output,
+                        context,
+                    )
+
+                    metrics = calculate_metrics(
+                        python_output,
+                        cpp_output,
+                    )
+                    validation_passed = (
+                        metrics.mean_absolute_error
+                        <= arguments.max_mae
+                        and metrics.maximum_absolute_error
+                        <= arguments.max_absolute_error
+                    )
+
+                    if not validation_passed:
+                        failure_count += 1
+
+                    rows.append(
+                        {
+                            "algorithm": algorithm_name,
+                            "resolution": resolution_name,
+                            "frame_index": frame_index,
+                            "reference_architecture": (
+                                "pure_python"
+                            ),
+                            "comparison_architecture": (
+                                "hybrid_and_pure_cpp_shared_core"
+                            ),
+                            "mean_absolute_error": (
+                                f"{metrics.mean_absolute_error:.6f}"
+                            ),
+                            "maximum_absolute_error": (
+                                metrics.maximum_absolute_error
+                            ),
+                            "psnr": format_psnr(metrics.psnr),
+                            "exact_match": str(
+                                metrics.exact_match
+                            ).lower(),
+                            "validation_passed": str(
+                                validation_passed
+                            ).lower(),
+                        }
+                    )
+
+                    status = (
+                        "PASS" if validation_passed else "FAIL"
+                    )
+                    print(
+                        f"{status} | {algorithm_name} | "
+                        f"{resolution_name} | "
+                        f"frame {frame_index} | "
+                        f"MAE {metrics.mean_absolute_error:.6f} | "
+                        "max error "
+                        f"{metrics.maximum_absolute_error}"
+                    )
+    finally:
+        capture.release()
+
+    fieldnames = [
+        "algorithm",
+        "resolution",
+        "frame_index",
+        "reference_architecture",
+        "comparison_architecture",
+        "mean_absolute_error",
+        "maximum_absolute_error",
+        "psnr",
+        "exact_match",
+        "validation_passed",
+    ]
+
+    with output_path.open(
+        "w",
+        newline="",
+        encoding="utf-8",
+    ) as output_file:
+        writer = csv.DictWriter(
+            output_file,
+            fieldnames=fieldnames,
+        )
+        writer.writeheader()
+        writer.writerows(rows)
+
+    print(f"Validation results created: {output_path}")
+
+    if failure_count > 0:
+        print(
+            f"Output equivalence failed for {failure_count} "
+            "comparison(s)."
+        )
+        return 1
+
+    print(
+        f"Output equivalence passed for {len(rows)} "
+        "comparison(s)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/validation/validate_output_equivalence.py
+++ b/benchmarks/validation/validate_output_equivalence.py
@@ -528,7 +528,7 @@ def main() -> int:
                                 "hybrid_and_pure_cpp_shared_core"
                             ),
                             "mean_absolute_error": (
-                                f"{metrics.mean_absolute_error:.6f}"
+                                repr(metrics.mean_absolute_error)
                             ),
                             "maximum_absolute_error": (
                                 metrics.maximum_absolute_error


### PR DESCRIPTION
## Overview

This PR adds deterministic output-equivalence validation for the VisionLab benchmark implementations.

Performance comparisons are meaningful only when the compared implementations produce equivalent outputs for the same input frame, algorithm, resolution, and parameters.

## Changes

* Add `benchmarks/validation/validate_output_equivalence.py`.
* Compare the Pure Python implementation against the shared C++ `ImageProcess` core used by both Hybrid Python+C++ and Pure C++.
* Select five deterministic frames distributed across the benchmark video.
* Validate every configured algorithm and resolution.
* Reject output shape, data-type, and empty-output mismatches.
* Calculate and export:

  * Mean absolute error
  * Maximum absolute error
  * PSNR
  * Exact pixel-match status
  * Validation status
* Write generated results to:

  * `benchmarks/results/output_equivalence_results.csv`
* Exit with a non-zero status when the configured equivalence thresholds are exceeded.
* Document Linux, macOS, PowerShell, and Git Bash execution instructions.

## Validation result

The default validation requires:

```text
Mean absolute error: 0
Maximum absolute error: 0
```

The validation completed successfully for:

```text
5 frames × 3 resolutions × 4 algorithms
= 60 comparisons
```

All 60 comparisons passed with exact pixel-level equivalence.

## Test commands

```bash
python -m py_compile benchmarks/validation/validate_output_equivalence.py
python benchmarks/validation/validate_output_equivalence.py
```

Expected final output:

```text
Output equivalence passed for 60 comparison(s).
```

Generated CSV results are ignored by Git and are not included in this PR.

Closes #12