### PR TITLE
fix: align Python OpenCV versions

### DIFF
--- a/hybrid-python-cpp/requirements.txt
+++ b/hybrid-python-cpp/requirements.txt
@@ -1,3 +1,3 @@
-numpy
-opencv-python
+numpy==2.5.2
+opencv-python==4.11.0.86
 pybind11

--- a/pure-python/requirements.txt
+++ b/pure-python/requirements.txt
@@ -1,2 +1,2 @@
-numpy
-opencv-python
+numpy==2.5.2
+opencv-python==4.11.0.86


### PR DESCRIPTION
## Overview

This PR aligns the OpenCV versions used across the Pure Python, Hybrid Python+C++, and Pure C++ benchmark architectures.

Previously, the Python environments used OpenCV 5.0.0 while the C++ builds used OpenCV 4.11.0. This mismatch could introduce library-version differences into the performance and output comparisons.

## Changes

* Pin `numpy==2.5.2` in the Pure Python environment.
* Pin `numpy==2.5.2` in the Hybrid Python+C++ environment.
* Pin `opencv-python==4.11.0.86` in both Python environments.
* Keep the benchmark algorithms and configuration unchanged.

## Resulting dependency versions

* Pure Python OpenCV: 4.11.0
* Hybrid Python OpenCV: 4.11.0
* Hybrid C++ OpenCV: 4.11.0
* Pure C++ OpenCV: 4.11.0
* Pure Python NumPy: 2.5.2
* Hybrid Python NumPy: 2.5.2

## Validation

The following checks completed successfully:

```bash
python -c "import cv2, numpy; print(cv2.__version__, numpy.__version__)"
python benchmarks/validation/validate_output_equivalence.py
python benchmarks/environment/collect_environment.py
```

Results:

* Both Python environments report OpenCV 4.11.0 and NumPy 2.5.2.
* Output-equivalence validation passes for all 60 comparisons.
* Generated environment metadata reports consistent OpenCV versions across all benchmark architectures.
* No algorithm implementation or benchmark parameter was changed.

## Motivation

All architectures must use equivalent dependency versions before official benchmark measurements are collected. This ensures that observed differences can be attributed to architectural choices rather than different OpenCV releases.

Closes #16