### PR TITLE
feat: add benchmark visualizations and comparative analysis

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -588,6 +588,8 @@ benchmark_trial_summary.csv
 benchmark_summary.csv
 benchmark_resource_summary.csv
 environment_metadata.json
+benchmark_comparison.csv
+figures/
 ```
 
 The first three files contain per-frame measurements. `benchmark_trial_summary.csv` and `benchmark_summary.csv` contain trial-level and overall statistics. `benchmark_resource_summary.csv` contains architecture-level wall-clock time, CPU time, average CPU utilization, peak resident memory, sampling information, and process exit status. `environment_metadata.json` contains the experimental environment metadata recorded by `collect_environment.py`.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -568,6 +568,14 @@ The analyzer validates the result files against the current benchmark configurat
 
 If the configuration changes, rerun all three implementations before analyzing the results.
 
+### 10.1. Generate comparative metrics and figures
+
+After the analyzer and resource-monitored benchmark run complete successfully, generate the comparative metrics and figures:
+
+```bash
+python benchmarks/analysis/generate_visualizations.py
+```
+
 ## 11. Expected output files
 
 After a successful benchmark and analysis run, `benchmarks/results/` must contain:

--- a/benchmarks/analysis/generate_visualizations.py
+++ b/benchmarks/analysis/generate_visualizations.py
@@ -7,6 +7,13 @@ from pathlib import Path
 from statistics import fmean, stdev
 
 from scipy.stats import t as student_t
+from collections.abc import Callable, Sequence
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
@@ -42,6 +49,32 @@ COMPARISON_OUTPUT_PATH = (
     RESULTS_DIRECTORY
     / "benchmark_comparison.csv"
 )
+
+FIGURES_DIRECTORY = (
+    RESULTS_DIRECTORY
+    / "figures"
+)
+
+ARCHITECTURE_LABELS = {
+    "pure_python": "Pure Python",
+    "hybrid": "Hybrid Python+C++",
+    "pure_cpp": "Pure C++",
+}
+
+ARCHITECTURE_COLORS = {
+    "pure_python": "#4C78A8",
+    "hybrid": "#F58518",
+    "pure_cpp": "#54A24B",
+}
+
+ALGORITHM_LABELS = {
+    "original": "Original",
+    "gamma_correction": "Gamma Correction",
+    "histogram_equalization": (
+        "Histogram Equalization"
+    ),
+    "clahe": "CLAHE",
+}
 
 EXPECTED_ARCHITECTURES = (
     "pure_python",
@@ -834,6 +867,478 @@ def write_comparison_summaries(
 
     return COMPARISON_OUTPUT_PATH
 
+MetricRecord = ComparisonSummary | OverallSummary
+
+
+def load_plot_order(
+) -> tuple[list[str], list[str]]:
+    with CONFIG_PATH.open(
+        "r",
+        encoding="utf-8",
+    ) as config_file:
+        config = json.load(config_file)
+
+    algorithms = [
+        str(algorithm["name"])
+        for algorithm in config["algorithms"]
+    ]
+
+    resolutions = [
+        (
+            f"{int(resolution['width'])}"
+            f"x{int(resolution['height'])}"
+        )
+        for resolution in config["resolutions"]
+    ]
+
+    return algorithms, resolutions
+
+
+def save_figure(
+    figure,
+    output_name: str,
+) -> Path:
+    FIGURES_DIRECTORY.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    output_path = (
+        FIGURES_DIRECTORY / output_name
+    )
+
+    figure.savefig(
+        output_path,
+        dpi=300,
+        bbox_inches="tight",
+        metadata={
+            "Software": (
+                "VisionLab benchmark visualization"
+            ),
+        },
+    )
+
+    plt.close(figure)
+
+    return output_path
+
+
+def create_grouped_metric_figure(
+    records: Sequence[MetricRecord],
+    value_getter: Callable[
+        [MetricRecord],
+        float,
+    ],
+    output_name: str,
+    title: str,
+    y_axis_label: str,
+    error_getter: (
+        Callable[
+            [MetricRecord],
+            tuple[float, float],
+        ]
+        | None
+    ) = None,
+) -> Path:
+    algorithms, resolutions = load_plot_order()
+
+    record_by_key = {
+        (
+            record.architecture,
+            record.algorithm,
+            record.resolution,
+        ): record
+        for record in records
+    }
+
+    column_count = min(
+        2,
+        len(algorithms),
+    )
+    row_count = math.ceil(
+        len(algorithms) / column_count
+    )
+
+    figure, axes = plt.subplots(
+        row_count,
+        column_count,
+        figsize=(
+            13,
+            4.5 * row_count,
+        ),
+        squeeze=False,
+    )
+
+    flattened_axes = axes.flatten()
+    bar_width = 0.24
+    base_positions = list(
+        range(len(resolutions))
+    )
+
+    for algorithm_index, algorithm in enumerate(
+        algorithms
+    ):
+        axis = flattened_axes[algorithm_index]
+
+        for architecture_index, architecture in enumerate(
+            EXPECTED_ARCHITECTURES
+        ):
+            horizontal_offset = (
+                architecture_index
+                - (
+                    len(EXPECTED_ARCHITECTURES)
+                    - 1
+                )
+                / 2.0
+            ) * bar_width
+
+            positions = [
+                position + horizontal_offset
+                for position in base_positions
+            ]
+
+            architecture_records = []
+
+            for resolution in resolutions:
+                key = (
+                    architecture,
+                    algorithm,
+                    resolution,
+                )
+
+                if key not in record_by_key:
+                    raise ValueError(
+                        "Missing visualization group: "
+                        f"{key}"
+                    )
+
+                architecture_records.append(
+                    record_by_key[key]
+                )
+
+            values = [
+                value_getter(record)
+                for record in architecture_records
+            ]
+
+            y_errors = None
+
+            if error_getter is not None:
+                errors = [
+                    error_getter(record)
+                    for record in architecture_records
+                ]
+
+                y_errors = [
+                    [
+                        max(0.0, error[0])
+                        for error in errors
+                    ],
+                    [
+                        max(0.0, error[1])
+                        for error in errors
+                    ],
+                ]
+
+            axis.bar(
+                positions,
+                values,
+                width=bar_width,
+                color=(
+                    ARCHITECTURE_COLORS[
+                        architecture
+                    ]
+                ),
+                label=(
+                    ARCHITECTURE_LABELS[
+                        architecture
+                    ]
+                ),
+                yerr=y_errors,
+                capsize=4 if y_errors else 0,
+                edgecolor="black",
+                linewidth=0.4,
+            )
+
+        axis.set_title(
+            ALGORITHM_LABELS.get(
+                algorithm,
+                algorithm.replace(
+                    "_",
+                    " ",
+                ).title(),
+            )
+        )
+        axis.set_xlabel("Resolution")
+        axis.set_ylabel(y_axis_label)
+        axis.set_xticks(base_positions)
+        axis.set_xticklabels(resolutions)
+        axis.set_ylim(bottom=0.0)
+        axis.grid(
+            axis="y",
+            linestyle="--",
+            alpha=0.35,
+        )
+        axis.set_axisbelow(True)
+
+    for unused_index in range(
+        len(algorithms),
+        len(flattened_axes),
+    ):
+        flattened_axes[unused_index].set_visible(
+            False
+        )
+
+    handles, labels = (
+        flattened_axes[0]
+        .get_legend_handles_labels()
+    )
+
+    figure.suptitle(
+        title,
+        fontsize=16,
+        fontweight="bold",
+        y=0.98,
+    )
+
+    figure.legend(
+        handles,
+        labels,
+        loc="upper center",
+        ncol=len(EXPECTED_ARCHITECTURES),
+        bbox_to_anchor=(0.5, 0.94),
+        frameon=False,
+    )
+
+    figure.tight_layout(
+        rect=(0.0, 0.0, 1.0, 0.89)
+    )
+
+    return save_figure(
+        figure,
+        output_name,
+    )
+
+
+def create_resource_bar_figure(
+    resource_summaries: Sequence[
+        ResourceSummary
+    ],
+    value_getter: Callable[
+        [ResourceSummary],
+        float,
+    ],
+    output_name: str,
+    title: str,
+    y_axis_label: str,
+) -> Path:
+    resource_by_architecture = {
+        summary.architecture: summary
+        for summary in resource_summaries
+    }
+
+    values = []
+    labels = []
+    colors = []
+
+    for architecture in EXPECTED_ARCHITECTURES:
+        if architecture not in resource_by_architecture:
+            raise ValueError(
+                "Missing resource summary for: "
+                f"{architecture}"
+            )
+
+        summary = resource_by_architecture[
+            architecture
+        ]
+
+        values.append(
+            value_getter(summary)
+        )
+        labels.append(
+            ARCHITECTURE_LABELS[architecture]
+        )
+        colors.append(
+            ARCHITECTURE_COLORS[architecture]
+        )
+
+    figure, axis = plt.subplots(
+        figsize=(8.5, 5.5)
+    )
+
+    bars = axis.bar(
+        labels,
+        values,
+        color=colors,
+        edgecolor="black",
+        linewidth=0.5,
+    )
+
+    axis.bar_label(
+        bars,
+        labels=[
+            f"{value:.2f}"
+            for value in values
+        ],
+        padding=4,
+    )
+
+    axis.set_title(
+        title,
+        fontsize=14,
+        fontweight="bold",
+    )
+    axis.set_ylabel(y_axis_label)
+    axis.set_ylim(
+        bottom=0.0,
+        top=max(values) * 1.15,
+    )
+    axis.grid(
+        axis="y",
+        linestyle="--",
+        alpha=0.35,
+    )
+    axis.set_axisbelow(True)
+
+    figure.tight_layout()
+
+    return save_figure(
+        figure,
+        output_name,
+    )
+
+
+def generate_visualization_figures(
+    comparisons: list[ComparisonSummary],
+    overall_summaries: list[OverallSummary],
+    resource_summaries: list[ResourceSummary],
+) -> list[Path]:
+    figure_paths = []
+
+    figure_paths.append(
+        create_grouped_metric_figure(
+            records=comparisons,
+            value_getter=lambda record: (
+                record.mean_processing_time_ms
+            ),
+            error_getter=lambda record: (
+                (
+                    record.mean_processing_time_ms
+                    - record.confidence_interval_95_lower_ms
+                ),
+                (
+                    record.confidence_interval_95_upper_ms
+                    - record.mean_processing_time_ms
+                ),
+            ),
+            output_name=(
+                "mean_processing_time_ms.png"
+            ),
+            title=(
+                "Mean Processing Time by Architecture"
+            ),
+            y_axis_label=(
+                "Processing Time (ms)"
+            ),
+        )
+    )
+
+    figure_paths.append(
+        create_grouped_metric_figure(
+            records=comparisons,
+            value_getter=lambda record: (
+                record.effective_fps
+            ),
+            output_name="effective_fps.png",
+            title=(
+                "Effective FPS by Architecture"
+            ),
+            y_axis_label="Effective FPS",
+        )
+    )
+
+    figure_paths.append(
+        create_grouped_metric_figure(
+            records=overall_summaries,
+            value_getter=lambda record: (
+                record.p95_ms
+            ),
+            output_name=(
+                "p95_processing_time_ms.png"
+            ),
+            title=(
+                "P95 Processing Time by Architecture"
+            ),
+            y_axis_label=(
+                "P95 Processing Time (ms)"
+            ),
+        )
+    )
+
+    figure_paths.append(
+        create_grouped_metric_figure(
+            records=comparisons,
+            value_getter=lambda record: (
+                record.speedup_vs_pure_python
+            ),
+            output_name=(
+                "speedup_vs_pure_python.png"
+            ),
+            title=(
+                "Speedup Relative to Pure Python"
+            ),
+            y_axis_label="Speedup (×)",
+        )
+    )
+
+    figure_paths.append(
+        create_resource_bar_figure(
+            resource_summaries=resource_summaries,
+            value_getter=lambda summary: (
+                summary.average_cpu_percent
+            ),
+            output_name=(
+                "average_cpu_percent.png"
+            ),
+            title=(
+                "Average CPU Utilization"
+            ),
+            y_axis_label="Average CPU (%)",
+        )
+    )
+
+    figure_paths.append(
+        create_resource_bar_figure(
+            resource_summaries=resource_summaries,
+            value_getter=lambda summary: (
+                summary.peak_rss_mib
+            ),
+            output_name="peak_rss_mib.png",
+            title=(
+                "Peak Resident Memory Usage"
+            ),
+            y_axis_label="Peak RSS (MiB)",
+        )
+    )
+
+    figure_paths.append(
+        create_resource_bar_figure(
+            resource_summaries=resource_summaries,
+            value_getter=lambda summary: (
+                summary.wall_time_seconds
+            ),
+            output_name=(
+                "wall_time_seconds.png"
+            ),
+            title=(
+                "Total Benchmark Wall-Clock Time"
+            ),
+            y_axis_label="Wall Time (seconds)",
+        )
+    )
+
+    return figure_paths
+
 def main() -> None:
     trial_summaries = load_trial_summaries()
     overall_summaries = load_overall_summaries()
@@ -854,6 +1359,12 @@ def main() -> None:
         )
     )
 
+    figure_paths = generate_visualization_figures(
+        comparisons,
+        overall_summaries,
+        resource_summaries,
+    )
+
     print("Visualization inputs validated.")
     print(
         f"Trial summaries: {len(trial_summaries)}"
@@ -868,6 +1379,11 @@ def main() -> None:
         "Comparison summary created: "
         f"{comparison_output_path}"
     )
+
+    print("Visualization figures created:")
+
+    for figure_path in figure_paths:
+        print(f"  {figure_path}")
 
 if __name__ == "__main__":
     main()

--- a/benchmarks/analysis/generate_visualizations.py
+++ b/benchmarks/analysis/generate_visualizations.py
@@ -578,6 +578,41 @@ def validate_experiment_coverage(
         for summary in overall_summaries
     }
 
+    expected_architecture_groups = {
+        (
+            architecture,
+            algorithm,
+            resolution,
+        )
+        for architecture in EXPECTED_ARCHITECTURES
+        for algorithm, resolution in expected_groups
+    }
+
+    observed_trial_groups = set(trials_by_group)
+    observed_overall_groups = set(overall_by_group)
+
+    if (
+        observed_trial_groups
+        != expected_architecture_groups
+    ):
+        raise ValueError(
+            "Trial summary group coverage mismatch. "
+            f"Expected "
+            f"{sorted(expected_architecture_groups)}, "
+            f"found {sorted(observed_trial_groups)}."
+        )
+
+    if (
+        observed_overall_groups
+        != expected_architecture_groups
+    ):
+        raise ValueError(
+            "Overall summary group coverage mismatch. "
+            f"Expected "
+            f"{sorted(expected_architecture_groups)}, "
+            f"found {sorted(observed_overall_groups)}."
+        )
+
     for architecture in EXPECTED_ARCHITECTURES:
         for algorithm, resolution in expected_groups:
             group_key = (

--- a/benchmarks/analysis/generate_visualizations.py
+++ b/benchmarks/analysis/generate_visualizations.py
@@ -1,0 +1,601 @@
+import csv
+import json
+import math
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+CONFIG_PATH = (
+    PROJECT_ROOT
+    / "benchmarks"
+    / "config"
+    / "benchmark_config.json"
+)
+
+RESULTS_DIRECTORY = (
+    PROJECT_ROOT
+    / "benchmarks"
+    / "results"
+)
+
+TRIAL_SUMMARY_PATH = (
+    RESULTS_DIRECTORY
+    / "benchmark_trial_summary.csv"
+)
+
+OVERALL_SUMMARY_PATH = (
+    RESULTS_DIRECTORY
+    / "benchmark_summary.csv"
+)
+
+RESOURCE_SUMMARY_PATH = (
+    RESULTS_DIRECTORY
+    / "benchmark_resource_summary.csv"
+)
+
+EXPECTED_ARCHITECTURES = (
+    "pure_python",
+    "hybrid",
+    "pure_cpp",
+)
+
+
+@dataclass(frozen=True)
+class TrialSummary:
+    architecture: str
+    algorithm: str
+    resolution: str
+    trial: int
+    frame_count: int
+    mean_ms: float
+    p95_ms: float
+    effective_fps: float
+
+
+@dataclass(frozen=True)
+class OverallSummary:
+    architecture: str
+    algorithm: str
+    resolution: str
+    trial_count: int
+    frame_count: int
+    mean_ms: float
+    p95_ms: float
+    effective_fps: float
+
+
+@dataclass(frozen=True)
+class ResourceSummary:
+    architecture: str
+    wall_time_seconds: float
+    cpu_time_seconds: float
+    average_cpu_percent: float
+    peak_rss_mib: float
+    sample_count: int
+    sampling_interval_seconds: float
+    exit_code: int
+
+
+def read_csv_rows(
+    input_path: Path,
+    required_fields: set[str],
+) -> list[dict[str, str]]:
+    if not input_path.is_file():
+        raise FileNotFoundError(
+            f"Required result file was not found: "
+            f"{input_path}"
+        )
+
+    with input_path.open(
+        "r",
+        newline="",
+        encoding="utf-8",
+    ) as input_file:
+        reader = csv.DictReader(input_file)
+
+        if reader.fieldnames is None:
+            raise ValueError(
+                f"CSV header is missing: {input_path}"
+            )
+
+        missing_fields = (
+            required_fields - set(reader.fieldnames)
+        )
+
+        if missing_fields:
+            raise ValueError(
+                f"Missing fields in {input_path}: "
+                f"{sorted(missing_fields)}"
+            )
+
+        rows = list(reader)
+
+    if not rows:
+        raise ValueError(
+            f"CSV file contains no data rows: {input_path}"
+        )
+
+    return rows
+
+
+def parse_non_negative_float(
+    row: dict[str, str],
+    field_name: str,
+    input_path: Path,
+) -> float:
+    try:
+        value = float(row[field_name])
+    except (TypeError, ValueError) as error:
+        raise ValueError(
+            f"Invalid {field_name} in {input_path}: "
+            f"{row.get(field_name)!r}"
+        ) from error
+
+    if not math.isfinite(value) or value < 0.0:
+        raise ValueError(
+            f"Invalid {field_name} in {input_path}: "
+            f"{value}"
+        )
+
+    return value
+
+
+def parse_positive_integer(
+    row: dict[str, str],
+    field_name: str,
+    input_path: Path,
+) -> int:
+    try:
+        value = int(row[field_name])
+    except (TypeError, ValueError) as error:
+        raise ValueError(
+            f"Invalid {field_name} in {input_path}: "
+            f"{row.get(field_name)!r}"
+        ) from error
+
+    if value <= 0:
+        raise ValueError(
+            f"{field_name} must be positive in "
+            f"{input_path}: {value}"
+        )
+
+    return value
+
+
+def validate_architecture(
+    architecture: str,
+    input_path: Path,
+) -> None:
+    if architecture not in EXPECTED_ARCHITECTURES:
+        raise ValueError(
+            f"Unexpected architecture in {input_path}: "
+            f"{architecture!r}"
+        )
+
+
+def load_expected_experiment(
+) -> tuple[set[tuple[str, str]], set[int]]:
+    if not CONFIG_PATH.is_file():
+        raise FileNotFoundError(
+            f"Benchmark configuration was not found: "
+            f"{CONFIG_PATH}"
+        )
+
+    with CONFIG_PATH.open(
+        "r",
+        encoding="utf-8",
+    ) as config_file:
+        config = json.load(config_file)
+
+    algorithms = {
+        str(algorithm["name"])
+        for algorithm in config["algorithms"]
+    }
+
+    resolutions = {
+        (
+            f"{int(resolution['width'])}"
+            f"x{int(resolution['height'])}"
+        )
+        for resolution in config["resolutions"]
+    }
+
+    trial_count = int(
+        config["benchmark"]["trials"]
+    )
+
+    if not algorithms or not resolutions:
+        raise ValueError(
+            "Benchmark configuration contains no "
+            "algorithms or resolutions."
+        )
+
+    if trial_count <= 0:
+        raise ValueError(
+            "Benchmark trial count must be positive."
+        )
+
+    expected_groups = {
+        (algorithm, resolution)
+        for algorithm in algorithms
+        for resolution in resolutions
+    }
+
+    expected_trials = set(
+        range(1, trial_count + 1)
+    )
+
+    return expected_groups, expected_trials
+
+
+def load_trial_summaries() -> list[TrialSummary]:
+    required_fields = {
+        "architecture",
+        "algorithm",
+        "resolution",
+        "trial",
+        "frame_count",
+        "mean_ms",
+        "p95_ms",
+        "effective_fps",
+    }
+
+    rows = read_csv_rows(
+        TRIAL_SUMMARY_PATH,
+        required_fields,
+    )
+
+    summaries = []
+    observed_keys = set()
+
+    for row in rows:
+        architecture = row["architecture"]
+        validate_architecture(
+            architecture,
+            TRIAL_SUMMARY_PATH,
+        )
+
+        summary = TrialSummary(
+            architecture=architecture,
+            algorithm=row["algorithm"],
+            resolution=row["resolution"],
+            trial=parse_positive_integer(
+                row,
+                "trial",
+                TRIAL_SUMMARY_PATH,
+            ),
+            frame_count=parse_positive_integer(
+                row,
+                "frame_count",
+                TRIAL_SUMMARY_PATH,
+            ),
+            mean_ms=parse_non_negative_float(
+                row,
+                "mean_ms",
+                TRIAL_SUMMARY_PATH,
+            ),
+            p95_ms=parse_non_negative_float(
+                row,
+                "p95_ms",
+                TRIAL_SUMMARY_PATH,
+            ),
+            effective_fps=parse_non_negative_float(
+                row,
+                "effective_fps",
+                TRIAL_SUMMARY_PATH,
+            ),
+        )
+
+        key = (
+            summary.architecture,
+            summary.algorithm,
+            summary.resolution,
+            summary.trial,
+        )
+
+        if key in observed_keys:
+            raise ValueError(
+                f"Duplicate trial summary group: {key}"
+            )
+
+        observed_keys.add(key)
+        summaries.append(summary)
+
+    return summaries
+
+
+def load_overall_summaries(
+) -> list[OverallSummary]:
+    required_fields = {
+        "architecture",
+        "algorithm",
+        "resolution",
+        "trial_count",
+        "frame_count",
+        "mean_ms",
+        "p95_ms",
+        "effective_fps",
+    }
+
+    rows = read_csv_rows(
+        OVERALL_SUMMARY_PATH,
+        required_fields,
+    )
+
+    summaries = []
+    observed_keys = set()
+
+    for row in rows:
+        architecture = row["architecture"]
+        validate_architecture(
+            architecture,
+            OVERALL_SUMMARY_PATH,
+        )
+
+        summary = OverallSummary(
+            architecture=architecture,
+            algorithm=row["algorithm"],
+            resolution=row["resolution"],
+            trial_count=parse_positive_integer(
+                row,
+                "trial_count",
+                OVERALL_SUMMARY_PATH,
+            ),
+            frame_count=parse_positive_integer(
+                row,
+                "frame_count",
+                OVERALL_SUMMARY_PATH,
+            ),
+            mean_ms=parse_non_negative_float(
+                row,
+                "mean_ms",
+                OVERALL_SUMMARY_PATH,
+            ),
+            p95_ms=parse_non_negative_float(
+                row,
+                "p95_ms",
+                OVERALL_SUMMARY_PATH,
+            ),
+            effective_fps=parse_non_negative_float(
+                row,
+                "effective_fps",
+                OVERALL_SUMMARY_PATH,
+            ),
+        )
+
+        key = (
+            summary.architecture,
+            summary.algorithm,
+            summary.resolution,
+        )
+
+        if key in observed_keys:
+            raise ValueError(
+                f"Duplicate overall summary group: {key}"
+            )
+
+        observed_keys.add(key)
+        summaries.append(summary)
+
+    return summaries
+
+
+def load_resource_summaries(
+) -> list[ResourceSummary]:
+    required_fields = {
+        "architecture",
+        "wall_time_seconds",
+        "cpu_time_seconds",
+        "average_cpu_percent",
+        "peak_rss_mib",
+        "sample_count",
+        "sampling_interval_seconds",
+        "exit_code",
+    }
+
+    rows = read_csv_rows(
+        RESOURCE_SUMMARY_PATH,
+        required_fields,
+    )
+
+    summaries = []
+    observed_architectures = set()
+
+    for row in rows:
+        architecture = row["architecture"]
+        validate_architecture(
+            architecture,
+            RESOURCE_SUMMARY_PATH,
+        )
+
+        try:
+            exit_code = int(row["exit_code"])
+        except (TypeError, ValueError) as error:
+            raise ValueError(
+                "Invalid exit_code in "
+                f"{RESOURCE_SUMMARY_PATH}: "
+                f"{row.get('exit_code')!r}"
+            ) from error
+
+        summary = ResourceSummary(
+            architecture=architecture,
+            wall_time_seconds=(
+                parse_non_negative_float(
+                    row,
+                    "wall_time_seconds",
+                    RESOURCE_SUMMARY_PATH,
+                )
+            ),
+            cpu_time_seconds=parse_non_negative_float(
+                row,
+                "cpu_time_seconds",
+                RESOURCE_SUMMARY_PATH,
+            ),
+            average_cpu_percent=(
+                parse_non_negative_float(
+                    row,
+                    "average_cpu_percent",
+                    RESOURCE_SUMMARY_PATH,
+                )
+            ),
+            peak_rss_mib=parse_non_negative_float(
+                row,
+                "peak_rss_mib",
+                RESOURCE_SUMMARY_PATH,
+            ),
+            sample_count=parse_positive_integer(
+                row,
+                "sample_count",
+                RESOURCE_SUMMARY_PATH,
+            ),
+            sampling_interval_seconds=(
+                parse_non_negative_float(
+                    row,
+                    "sampling_interval_seconds",
+                    RESOURCE_SUMMARY_PATH,
+                )
+            ),
+            exit_code=exit_code,
+        )
+
+        if summary.architecture in observed_architectures:
+            raise ValueError(
+                "Duplicate resource summary for: "
+                f"{summary.architecture}"
+            )
+
+        if summary.exit_code != 0:
+            raise ValueError(
+                f"{summary.architecture} has a non-zero "
+                f"exit code: {summary.exit_code}"
+            )
+
+        if summary.peak_rss_mib <= 0.0:
+            raise ValueError(
+                f"{summary.architecture} has an invalid "
+                "peak RSS value."
+            )
+
+        observed_architectures.add(
+            summary.architecture
+        )
+        summaries.append(summary)
+
+    if observed_architectures != set(
+        EXPECTED_ARCHITECTURES
+    ):
+        raise ValueError(
+            "Resource summary architecture mismatch. "
+            f"Expected {sorted(EXPECTED_ARCHITECTURES)}, "
+            f"found {sorted(observed_architectures)}."
+        )
+
+    return summaries
+
+
+def validate_experiment_coverage(
+    trial_summaries: list[TrialSummary],
+    overall_summaries: list[OverallSummary],
+) -> None:
+    (
+        expected_groups,
+        expected_trials,
+    ) = load_expected_experiment()
+
+    trials_by_group = defaultdict(set)
+
+    for summary in trial_summaries:
+        group_key = (
+            summary.architecture,
+            summary.algorithm,
+            summary.resolution,
+        )
+        trials_by_group[group_key].add(
+            summary.trial
+        )
+
+    overall_by_group = {
+        (
+            summary.architecture,
+            summary.algorithm,
+            summary.resolution,
+        ): summary
+        for summary in overall_summaries
+    }
+
+    for architecture in EXPECTED_ARCHITECTURES:
+        for algorithm, resolution in expected_groups:
+            group_key = (
+                architecture,
+                algorithm,
+                resolution,
+            )
+
+            if group_key not in overall_by_group:
+                raise ValueError(
+                    "Missing overall summary group: "
+                    f"{group_key}"
+                )
+
+            observed_trials = trials_by_group.get(
+                group_key,
+                set(),
+            )
+
+            if observed_trials != expected_trials:
+                raise ValueError(
+                    f"Trial mismatch for {group_key}. "
+                    f"Expected {sorted(expected_trials)}, "
+                    f"found {sorted(observed_trials)}."
+                )
+
+            overall = overall_by_group[group_key]
+
+            if overall.trial_count != len(
+                expected_trials
+            ):
+                raise ValueError(
+                    f"Invalid trial_count for {group_key}: "
+                    f"{overall.trial_count}"
+                )
+
+    expected_overall_count = (
+        len(EXPECTED_ARCHITECTURES)
+        * len(expected_groups)
+    )
+
+    if len(overall_summaries) != expected_overall_count:
+        raise ValueError(
+            "Unexpected overall summary group count. "
+            f"Expected {expected_overall_count}, "
+            f"found {len(overall_summaries)}."
+        )
+
+
+def main() -> None:
+    trial_summaries = load_trial_summaries()
+    overall_summaries = load_overall_summaries()
+    resource_summaries = load_resource_summaries()
+
+    validate_experiment_coverage(
+        trial_summaries,
+        overall_summaries,
+    )
+
+    print("Visualization inputs validated.")
+    print(
+        f"Trial summaries: {len(trial_summaries)}"
+    )
+    print(
+        f"Overall summaries: {len(overall_summaries)}"
+    )
+    print(
+        f"Resource summaries: {len(resource_summaries)}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/analysis/generate_visualizations.py
+++ b/benchmarks/analysis/generate_visualizations.py
@@ -4,7 +4,9 @@ import math
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
+from statistics import fmean, stdev
 
+from scipy.stats import t as student_t
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
@@ -34,6 +36,11 @@ OVERALL_SUMMARY_PATH = (
 RESOURCE_SUMMARY_PATH = (
     RESULTS_DIRECTORY
     / "benchmark_resource_summary.csv"
+)
+
+COMPARISON_OUTPUT_PATH = (
+    RESULTS_DIRECTORY
+    / "benchmark_comparison.csv"
 )
 
 EXPECTED_ARCHITECTURES = (
@@ -78,6 +85,18 @@ class ResourceSummary:
     sampling_interval_seconds: float
     exit_code: int
 
+@dataclass(frozen=True)
+class ComparisonSummary:
+    architecture: str
+    algorithm: str
+    resolution: str
+    trial_count: int
+    mean_processing_time_ms: float
+    confidence_interval_95_lower_ms: float
+    confidence_interval_95_upper_ms: float
+    effective_fps: float
+    speedup_vs_pure_python: float
+    overhead_vs_pure_cpp_percent: float
 
 def read_csv_rows(
     input_path: Path,
@@ -574,6 +593,246 @@ def validate_experiment_coverage(
             f"found {len(overall_summaries)}."
         )
 
+def calculate_confidence_interval(
+    values: list[float],
+) -> tuple[float, float, float]:
+    if len(values) < 2:
+        raise ValueError(
+            "At least two trial values are required "
+            "for a confidence interval."
+        )
+
+    mean_value = fmean(values)
+    standard_error = (
+        stdev(values) / math.sqrt(len(values))
+    )
+
+    critical_value = float(
+        student_t.ppf(
+            0.975,
+            df=len(values) - 1,
+        )
+    )
+
+    if not math.isfinite(critical_value):
+        raise ValueError(
+            "The confidence-interval critical value "
+            "is not finite."
+        )
+
+    margin = critical_value * standard_error
+
+    return (
+        mean_value,
+        mean_value - margin,
+        mean_value + margin,
+    )
+
+
+def resolution_sort_key(
+    resolution: str,
+) -> tuple[int, int]:
+    try:
+        width_text, height_text = resolution.split(
+            "x",
+            maxsplit=1,
+        )
+        return int(width_text), int(height_text)
+    except (TypeError, ValueError) as error:
+        raise ValueError(
+            f"Invalid resolution: {resolution!r}"
+        ) from error
+
+
+def build_comparison_summaries(
+    trial_summaries: list[TrialSummary],
+) -> list[ComparisonSummary]:
+    values_by_group = defaultdict(list)
+
+    for summary in trial_summaries:
+        key = (
+            summary.architecture,
+            summary.algorithm,
+            summary.resolution,
+        )
+
+        values_by_group[key].append(
+            summary.mean_ms
+        )
+
+    group_means = {
+        key: fmean(values)
+        for key, values in values_by_group.items()
+    }
+
+    architecture_order = {
+        architecture: index
+        for index, architecture
+        in enumerate(EXPECTED_ARCHITECTURES)
+    }
+
+    sorted_keys = sorted(
+        values_by_group,
+        key=lambda key: (
+            key[1],
+            resolution_sort_key(key[2]),
+            architecture_order[key[0]],
+        ),
+    )
+
+    comparisons = []
+
+    for architecture, algorithm, resolution in sorted_keys:
+        key = (
+            architecture,
+            algorithm,
+            resolution,
+        )
+        trial_values = values_by_group[key]
+
+        (
+            mean_ms,
+            confidence_lower_ms,
+            confidence_upper_ms,
+        ) = calculate_confidence_interval(
+            trial_values
+        )
+
+        pure_python_key = (
+            "pure_python",
+            algorithm,
+            resolution,
+        )
+        pure_cpp_key = (
+            "pure_cpp",
+            algorithm,
+            resolution,
+        )
+
+        pure_python_mean = group_means[
+            pure_python_key
+        ]
+        pure_cpp_mean = group_means[
+            pure_cpp_key
+        ]
+
+        if (
+            mean_ms <= 0.0
+            or pure_python_mean <= 0.0
+            or pure_cpp_mean <= 0.0
+        ):
+            raise ValueError(
+                "Processing-time means must be "
+                f"positive for {key}."
+            )
+
+        comparisons.append(
+            ComparisonSummary(
+                architecture=architecture,
+                algorithm=algorithm,
+                resolution=resolution,
+                trial_count=len(trial_values),
+                mean_processing_time_ms=mean_ms,
+                confidence_interval_95_lower_ms=(
+                    confidence_lower_ms
+                ),
+                confidence_interval_95_upper_ms=(
+                    confidence_upper_ms
+                ),
+                effective_fps=1000.0 / mean_ms,
+                speedup_vs_pure_python=(
+                    pure_python_mean / mean_ms
+                ),
+                overhead_vs_pure_cpp_percent=(
+                    (
+                        mean_ms - pure_cpp_mean
+                    )
+                    / pure_cpp_mean
+                    * 100.0
+                ),
+            )
+        )
+
+    return comparisons
+
+
+def write_comparison_summaries(
+    comparisons: list[ComparisonSummary],
+) -> Path:
+    if not comparisons:
+        raise ValueError(
+            "No benchmark comparisons were generated."
+        )
+
+    temporary_path = (
+        COMPARISON_OUTPUT_PATH.with_suffix(
+            ".csv.tmp"
+        )
+    )
+
+    fieldnames = [
+        "architecture",
+        "algorithm",
+        "resolution",
+        "trial_count",
+        "mean_processing_time_ms",
+        "confidence_interval_95_lower_ms",
+        "confidence_interval_95_upper_ms",
+        "effective_fps",
+        "speedup_vs_pure_python",
+        "overhead_vs_pure_cpp_percent",
+    ]
+
+    with temporary_path.open(
+        "w",
+        newline="",
+        encoding="utf-8",
+    ) as output_file:
+        writer = csv.DictWriter(
+            output_file,
+            fieldnames=fieldnames,
+        )
+        writer.writeheader()
+
+        for comparison in comparisons:
+            writer.writerow(
+                {
+                    "architecture": (
+                        comparison.architecture
+                    ),
+                    "algorithm": comparison.algorithm,
+                    "resolution": (
+                        comparison.resolution
+                    ),
+                    "trial_count": (
+                        comparison.trial_count
+                    ),
+                    "mean_processing_time_ms": (
+                        f"{comparison.mean_processing_time_ms:.6f}"
+                    ),
+                    "confidence_interval_95_lower_ms": (
+                        f"{comparison.confidence_interval_95_lower_ms:.6f}"
+                    ),
+                    "confidence_interval_95_upper_ms": (
+                        f"{comparison.confidence_interval_95_upper_ms:.6f}"
+                    ),
+                    "effective_fps": (
+                        f"{comparison.effective_fps:.6f}"
+                    ),
+                    "speedup_vs_pure_python": (
+                        f"{comparison.speedup_vs_pure_python:.6f}"
+                    ),
+                    "overhead_vs_pure_cpp_percent": (
+                        f"{comparison.overhead_vs_pure_cpp_percent:.6f}"
+                    ),
+                }
+            )
+
+    temporary_path.replace(
+        COMPARISON_OUTPUT_PATH
+    )
+
+    return COMPARISON_OUTPUT_PATH
 
 def main() -> None:
     trial_summaries = load_trial_summaries()
@@ -583,6 +842,16 @@ def main() -> None:
     validate_experiment_coverage(
         trial_summaries,
         overall_summaries,
+    )
+
+    comparisons = build_comparison_summaries(
+        trial_summaries
+    )
+
+    comparison_output_path = (
+        write_comparison_summaries(
+            comparisons
+        )
     )
 
     print("Visualization inputs validated.")
@@ -595,7 +864,10 @@ def main() -> None:
     print(
         f"Resource summaries: {len(resource_summaries)}"
     )
-
+    print(
+        "Comparison summary created: "
+        f"{comparison_output_path}"
+    )
 
 if __name__ == "__main__":
     main()

--- a/benchmarks/requirements.txt
+++ b/benchmarks/requirements.txt
@@ -1,1 +1,3 @@
+matplotlib==3.11.1
 psutil==7.2.2
+scipy==1.18.0


### PR DESCRIPTION
## Summary

This pull request adds comparative analysis and visualization support for the VisionLab benchmark results.

## Changes

* Added strict validation for trial, overall, and resource summary inputs.
* Added `benchmark_comparison.csv` generation.
* Added trial-level 95% confidence intervals using the Student's t-distribution.
* Added speedup calculations relative to Pure Python.
* Added overhead calculations relative to Pure C++.
* Added seven benchmark visualization figures:

  * Mean processing time with 95% confidence intervals
  * Effective FPS
  * P95 processing time
  * Speedup relative to Pure Python
  * Average CPU usage
  * Peak memory usage
  * Total wall-clock time
* Added Matplotlib and SciPy as benchmark analysis dependencies.
* Documented the visualization workflow and generated outputs.

## Validation

A complete benchmark run was performed successfully for all three architectures:

* 180 trial summaries
* 36 overall summaries
* 3 resource summaries
* 7 visualization figures

The benchmark result integrity validation completed successfully.

## Test commands

```bash
python benchmarks/orchestration/run_benchmarks.py
python benchmarks/analysis/generate_visualizations.py
```

Generated CSV and PNG result files remain excluded from version control and can be reproduced from validated benchmark data.