### PR TITLE
feat: add controlled illumination experiment metadata infrastructure

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -10,9 +10,10 @@ Run all commands from the repository root (`VisionLab/`) unless otherwise specif
 
 ## Experimental protocols
 
-The controlled-illumination evaluation protocol is documented at:
+The controlled-illumination experiment documentation is available at:
 
 - [Controlled-illumination evaluation protocol](experiments/controlled_illumination_protocol.md)
+- [Controlled-illumination experiment infrastructure](experiments/README.md)
 
 ## 1. Prepare the input video
 

--- a/benchmarks/experiments/README.md
+++ b/benchmarks/experiments/README.md
@@ -1,0 +1,294 @@
+# Controlled-Illumination Experiment Infrastructure
+
+This directory contains the configuration, metadata and validation infrastructure used to prepare and execute VisionLab controlled-illumination experiments.
+
+The scientific experiment procedure is defined in:
+
+```text
+benchmarks/experiments/controlled_illumination_protocol.md
+```
+
+The infrastructure in this directory does not perform the physical experiment automatically. It ensures that each experiment run is configurable, traceable, reproducible and validated before its results are analyzed.
+
+## Components
+
+| File                                                      | Purpose                                                                                                          |
+| --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `config/controlled_illumination_config.json`              | Defines the experiment phases, lighting conditions, algorithms, architectures, platforms and execution settings. |
+| `controlled_illumination_metadata.py`                     | Defines metadata models, configuration validation, run validation and atomic JSON storage.                       |
+| `generate_dry_run_metadata.py`                            | Generates a validated metadata example without requiring experiment hardware.                                    |
+| `validate_controlled_illumination_metadata.py`            | Validates one or more saved run metadata files.                                                                  |
+| `tests/test_controlled_illumination_metadata.py`          | Tests configuration, measurement, metadata and storage behavior.                                                 |
+| `tests/test_validate_controlled_illumination_metadata.py` | Tests the metadata-validation CLI.                                                                               |
+
+## Experiment phases
+
+Two experiment phases are represented separately.
+
+### Constant-lux phase
+
+The light-source output is adjusted until the required target-plane illuminance is reached. The incidence angle is then varied while the target illuminance is kept approximately constant.
+
+Metadata field:
+
+```text
+phase = constant_lux
+```
+
+A `constant_lux` run must define `target_illuminance_lux`.
+
+### Constant-source phase
+
+The light-source output setting remains fixed while the incidence angle is changed. The resulting illuminance is measured rather than controlled.
+
+Metadata field:
+
+```text
+phase = constant_source
+```
+
+A `constant_source` run must not define `target_illuminance_lux`. The measured centre and corner lux values are still required.
+
+Results from the two phases must not be combined as though they represented the same experimental condition.
+
+## Configuration
+
+The shared configuration file is:
+
+```text
+benchmarks/experiments/config/controlled_illumination_config.json
+```
+
+It defines:
+
+* Target illuminance levels
+* Light-incidence angles
+* Algorithms
+* Software architectures
+* Computing platforms
+* Resolutions
+* Trial count
+* Target frame rate
+* Warm-up and measured frame counts
+* Queue capacity and drop policy
+* Camera modes
+* Illuminance-measurement positions
+* Required run metadata
+* Output directory
+
+The algorithm names and parameters must remain compatible with:
+
+```text
+benchmarks/config/benchmark_config.json
+```
+
+Real-time execution settings must remain compatible with:
+
+```text
+benchmarks/config/realtime_config.json
+```
+
+Validate the configuration from the repository root:
+
+```bash
+python benchmarks/experiments/controlled_illumination_metadata.py
+```
+
+Expected output:
+
+```text
+Controlled-illumination configuration is valid.
+```
+
+## Dry-run metadata
+
+A dry run validates the metadata workflow without a lux meter, camera, Raspberry Pi or NVIDIA Jetson device.
+
+Run it from the repository root:
+
+```bash
+python -m benchmarks.experiments.generate_dry_run_metadata
+```
+
+The command:
+
+1. Loads and validates the experiment configuration.
+2. Reads the current Git commit SHA.
+3. Generates unique experiment and run identifiers.
+4. Creates placeholder camera, lighting and platform measurements.
+5. Validates the completed metadata record.
+6. Writes the metadata file atomically.
+
+Expected output begins with:
+
+```text
+Controlled-illumination dry run passed.
+Experiment ID:
+Run ID:
+Metadata created:
+```
+
+Dry-run records contain:
+
+```text
+dry_run = true
+```
+
+Dry-run records are infrastructure tests and must never be interpreted as physical experiment results.
+
+## Output structure
+
+By default, metadata files are written under:
+
+```text
+benchmarks/results/controlled_illumination/
+```
+
+The directory structure is:
+
+```text
+benchmarks/results/controlled_illumination/
+└── <platform>/
+    └── <experiment_id>/
+        └── <run_id>/
+            └── run_metadata.json
+```
+
+Generated results must not be committed to Git.
+
+After generating a dry run, verify this with:
+
+```bash
+git status --short
+```
+
+The generated `run_metadata.json` file should not appear.
+
+## Metadata validation
+
+Validate a single metadata file:
+
+```bash
+python -m \
+benchmarks.experiments.validate_controlled_illumination_metadata \
+path/to/run_metadata.json
+```
+
+Validate multiple metadata files:
+
+```bash
+python -m \
+benchmarks.experiments.validate_controlled_illumination_metadata \
+path/to/first/run_metadata.json \
+path/to/second/run_metadata.json
+```
+
+Use a custom configuration when required:
+
+```bash
+python -m \
+benchmarks.experiments.validate_controlled_illumination_metadata \
+--config path/to/controlled_illumination_config.json \
+path/to/run_metadata.json
+```
+
+Successful validation ends with:
+
+```text
+Controlled-illumination metadata validation passed.
+```
+
+A metadata record is rejected when it contains conditions such as:
+
+* Missing required fields
+* Invalid experiment phases
+* Unsupported algorithms, architectures or platforms
+* Unsupported resolutions
+* Invalid trial numbers
+* Unsupported incidence angles
+* Invalid constant-lux or constant-source fields
+* Missing camera settings
+* Invalid timestamps
+* Invalid Git commit SHAs
+* Inconsistent illuminance summaries
+* Invalid temperature measurements
+* Invalid frame deadlines
+* Unexpected metadata fields
+
+## Illuminance measurements
+
+Lux must be recorded at five target-plane positions:
+
+* Centre
+* Top left
+* Top right
+* Bottom left
+* Bottom right
+
+The metadata infrastructure calculates:
+
+* Mean lux
+* Minimum lux
+* Maximum lux
+
+When metadata is loaded, the stored summary values are recalculated and compared with the five original measurements. A modified or inconsistent summary is rejected.
+
+## Atomic storage
+
+Metadata is first written to a temporary file in the destination directory. The temporary file is flushed to disk and then atomically moved to the final `run_metadata.json` path.
+
+This prevents an interrupted write from leaving a partially written official metadata file.
+
+## Running the tests
+
+Run all controlled-illumination tests from the repository root:
+
+```bash
+python -m unittest discover \
+-s benchmarks/experiments/tests \
+-p "test_*.py" \
+-v
+```
+
+The tests cover:
+
+* Valid configuration loading
+* Lux summary calculation
+* Invalid lux rejection
+* Experiment-condition validation
+* Trial and incidence-angle validation
+* Camera-setting validation
+* Unique identifier generation
+* Atomic metadata storage
+* JSON metadata loading
+* Dry-run metadata generation
+* CLI success behavior
+* CLI failure behavior
+
+All tests must pass before publishing changes or collecting official experiment results.
+
+## Official experiment workflow
+
+For each official experiment run:
+
+1. Confirm that the working tree is clean.
+2. Record the full Git commit SHA.
+3. Select the experiment phase.
+4. Configure the platform, architecture, algorithm and resolution.
+5. Fix and record the camera settings.
+6. Configure the light source and incidence angle.
+7. Measure lux at all five target positions.
+8. Record device temperature and power settings.
+9. Execute the warm-up and measured frames.
+10. Complete and validate the run metadata.
+11. Save the metadata atomically.
+12. Validate the generated file with the CLI.
+13. Archive the raw results, configuration and metadata together.
+
+Official results must not be used when metadata validation fails.
+
+## Current scope
+
+The current infrastructure supports configuration and metadata preparation on the desktop reference platform.
+
+Physical measurements, Raspberry Pi deployment, NVIDIA Jetson deployment, hardware-specific acceleration and final architecture selection remain separate future stages.

--- a/benchmarks/experiments/config/controlled_illumination_config.json
+++ b/benchmarks/experiments/config/controlled_illumination_config.json
@@ -1,0 +1,160 @@
+{
+  "schema_version": 1,
+  "experiment": {
+    "name": "controlled_illumination_evaluation",
+    "protocol_path": "benchmarks/experiments/controlled_illumination_protocol.md",
+    "pilot_validation_required": true
+  },
+  "base_configs": {
+    "benchmark": "benchmarks/config/benchmark_config.json",
+    "realtime": "benchmarks/config/realtime_config.json"
+  },
+  "phases": [
+    {
+      "name": "constant_lux",
+      "description": "Keep target-plane illuminance approximately constant while changing the incidence angle.",
+      "controlled_variable": "target_illuminance_lux",
+      "source_output_policy": "adjust_to_target_lux"
+    },
+    {
+      "name": "constant_source",
+      "description": "Keep the light-source output constant while changing the incidence angle.",
+      "controlled_variable": "source_output_setting",
+      "source_output_policy": "fixed_within_trial_block"
+    }
+  ],
+  "experiment_matrix": {
+    "target_illuminance_levels_lux": [
+      5,
+      50,
+      200,
+      500,
+      1000
+    ],
+    "incidence_angles_degrees": [
+      0,
+      30,
+      60
+    ],
+    "algorithms": [
+      "original",
+      "gamma_correction",
+      "histogram_equalization",
+      "clahe"
+    ],
+    "architectures": [
+      "pure_python",
+      "hybrid",
+      "pure_cpp"
+    ],
+    "platforms": [
+      "desktop",
+      "raspberry_pi",
+      "nvidia_jetson"
+    ],
+    "resolutions": [
+      {
+        "width": 640,
+        "height": 480
+      },
+      {
+        "width": 1280,
+        "height": 720
+      },
+      {
+        "width": 1920,
+        "height": 1080
+      }
+    ],
+    "trial_count": 5
+  },
+  "execution": {
+    "target_fps": 30.0,
+    "queue_capacity": 1,
+    "warmup_frames": 30,
+    "measured_frames": 500,
+    "drop_policy": "latest_frame",
+    "deadline_multiplier": 1.0,
+    "randomize_run_order": true,
+    "randomization_seed": 20260821
+  },
+  "illuminance_measurement": {
+    "unit": "lux",
+    "positions": [
+      "centre",
+      "top_left",
+      "top_right",
+      "bottom_left",
+      "bottom_right"
+    ],
+    "required_summary_values": [
+      "mean_lux",
+      "minimum_lux",
+      "maximum_lux"
+    ],
+    "required_device_fields": [
+      "lux_meter_model",
+      "lux_meter_range",
+      "lux_meter_resolution"
+    ]
+  },
+  "camera_modes": {
+    "controlled": {
+      "automatic_exposure_allowed": false,
+      "automatic_white_balance_allowed": false,
+      "required_settings": [
+        "exposure_time",
+        "sensor_gain_or_iso",
+        "white_balance",
+        "focus",
+        "frame_rate",
+        "resolution",
+        "lens",
+        "aperture"
+      ]
+    },
+    "operational": {
+      "automatic_exposure_allowed": true,
+      "automatic_white_balance_allowed": true,
+      "reported_values_required": true
+    }
+  },
+  "required_run_metadata": [
+    "experiment_id",
+    "run_id",
+    "collected_at_utc",
+    "git_commit_sha",
+    "phase",
+    "device_id",
+    "operating_system",
+    "platform",
+    "architecture",
+    "algorithm",
+    "algorithm_parameters",
+    "resolution",
+    "trial_number",
+    "target_fps",
+    "frame_deadline_ms",
+    "target_illuminance_lux",
+    "measured_illuminance",
+    "incidence_angle_degrees",
+    "source_output_setting",
+    "camera_mode",
+    "camera_settings",
+    "camera_to_target_distance_metres",
+    "light_to_target_distance_metres",
+    "input_scene_id",
+    "power_mode",
+    "clock_configuration",
+    "starting_temperature_celsius",
+    "ending_temperature_celsius",
+    "maximum_temperature_celsius",
+    "thermal_throttling_detected",
+    "software_versions"
+  ],
+  "output": {
+    "directory": "benchmarks/results/controlled_illumination",
+    "metadata_file_name": "run_metadata.json",
+    "generated_results_must_not_be_committed": true
+  }
+}

--- a/benchmarks/experiments/controlled_illumination_metadata.py
+++ b/benchmarks/experiments/controlled_illumination_metadata.py
@@ -719,6 +719,7 @@ def require_finite_metadata_number(
 
     return float(value)
 
+
 def validate_run_metadata(
     metadata: ControlledIlluminationRunMetadata,
     config: dict[str, Any],
@@ -766,8 +767,6 @@ def validate_run_metadata(
         )
 
     git_commit_sha = metadata.git_commit_sha.lower()
-
-
 
     if (
         len(git_commit_sha) != 40

--- a/benchmarks/experiments/controlled_illumination_metadata.py
+++ b/benchmarks/experiments/controlled_illumination_metadata.py
@@ -1,0 +1,483 @@
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+DEFAULT_CONFIG_PATH = (
+    PROJECT_ROOT
+    / "benchmarks"
+    / "experiments"
+    / "config"
+    / "controlled_illumination_config.json"
+)
+
+REQUIRED_PHASES = {
+    "constant_lux",
+    "constant_source",
+}
+
+REQUIRED_ILLUMINANCE_POSITIONS = {
+    "centre",
+    "top_left",
+    "top_right",
+    "bottom_left",
+    "bottom_right",
+}
+
+REQUIRED_RUN_METADATA_FIELDS = {
+    "experiment_id",
+    "run_id",
+    "collected_at_utc",
+    "git_commit_sha",
+    "phase",
+    "platform",
+    "architecture",
+    "algorithm",
+    "resolution",
+    "trial_number",
+    "measured_illuminance",
+    "incidence_angle_degrees",
+    "camera_settings",
+}
+
+
+class ControlledIlluminationConfigError(ValueError):
+    """Raised when the experiment configuration is invalid."""
+
+
+def require_mapping(
+    value: Any,
+    field_name: str,
+) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ControlledIlluminationConfigError(
+            f"{field_name} must be an object."
+        )
+
+    return value
+
+
+def require_list(
+    value: Any,
+    field_name: str,
+) -> list[Any]:
+    if not isinstance(value, list) or not value:
+        raise ControlledIlluminationConfigError(
+            f"{field_name} must be a non-empty list."
+        )
+
+    return value
+
+
+def require_non_empty_string(
+    value: Any,
+    field_name: str,
+) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ControlledIlluminationConfigError(
+            f"{field_name} must be a non-empty string."
+        )
+
+    return value
+
+
+def require_positive_integer(
+    value: Any,
+    field_name: str,
+) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value <= 0
+    ):
+        raise ControlledIlluminationConfigError(
+            f"{field_name} must be a positive integer."
+        )
+
+    return value
+
+
+def require_non_negative_integer(
+    value: Any,
+    field_name: str,
+) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value < 0
+    ):
+        raise ControlledIlluminationConfigError(
+            f"{field_name} must be a non-negative integer."
+        )
+
+    return value
+
+
+def require_positive_number(
+    value: Any,
+    field_name: str,
+) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+        or value <= 0
+    ):
+        raise ControlledIlluminationConfigError(
+            f"{field_name} must be a positive finite number."
+        )
+
+    return float(value)
+
+
+def validate_unique_strings(
+    values: Any,
+    field_name: str,
+) -> list[str]:
+    items = require_list(values, field_name)
+
+    for item in items:
+        require_non_empty_string(item, field_name)
+
+    if len(items) != len(set(items)):
+        raise ControlledIlluminationConfigError(
+            f"{field_name} contains duplicate values."
+        )
+
+    return items
+
+
+def validate_experiment_matrix(
+    matrix: dict[str, Any],
+) -> None:
+    illuminance_levels = require_list(
+        matrix.get("target_illuminance_levels_lux"),
+        "experiment_matrix.target_illuminance_levels_lux",
+    )
+
+    for index, value in enumerate(illuminance_levels):
+        require_positive_number(
+            value,
+            (
+                "experiment_matrix."
+                f"target_illuminance_levels_lux[{index}]"
+            ),
+        )
+
+    if len(illuminance_levels) != len(
+        set(illuminance_levels)
+    ):
+        raise ControlledIlluminationConfigError(
+            "Illuminance levels must be unique."
+        )
+
+    incidence_angles = require_list(
+        matrix.get("incidence_angles_degrees"),
+        "experiment_matrix.incidence_angles_degrees",
+    )
+
+    for index, angle in enumerate(incidence_angles):
+        if (
+            isinstance(angle, bool)
+            or not isinstance(angle, (int, float))
+            or not math.isfinite(angle)
+            or angle < 0
+            or angle > 90
+        ):
+            raise ControlledIlluminationConfigError(
+                "experiment_matrix."
+                f"incidence_angles_degrees[{index}] "
+                "must be between 0 and 90 degrees."
+            )
+
+    if len(incidence_angles) != len(
+        set(incidence_angles)
+    ):
+        raise ControlledIlluminationConfigError(
+            "Incidence angles must be unique."
+        )
+
+    validate_unique_strings(
+        matrix.get("algorithms"),
+        "experiment_matrix.algorithms",
+    )
+    validate_unique_strings(
+        matrix.get("architectures"),
+        "experiment_matrix.architectures",
+    )
+    validate_unique_strings(
+        matrix.get("platforms"),
+        "experiment_matrix.platforms",
+    )
+
+    resolutions = require_list(
+        matrix.get("resolutions"),
+        "experiment_matrix.resolutions",
+    )
+
+    resolution_pairs: set[tuple[int, int]] = set()
+
+    for index, resolution_value in enumerate(resolutions):
+        resolution = require_mapping(
+            resolution_value,
+            f"experiment_matrix.resolutions[{index}]",
+        )
+
+        width = require_positive_integer(
+            resolution.get("width"),
+            (
+                "experiment_matrix."
+                f"resolutions[{index}].width"
+            ),
+        )
+        height = require_positive_integer(
+            resolution.get("height"),
+            (
+                "experiment_matrix."
+                f"resolutions[{index}].height"
+            ),
+        )
+
+        resolution_pair = (width, height)
+
+        if resolution_pair in resolution_pairs:
+            raise ControlledIlluminationConfigError(
+                "Experiment resolutions must be unique."
+            )
+
+        resolution_pairs.add(resolution_pair)
+
+    require_positive_integer(
+        matrix.get("trial_count"),
+        "experiment_matrix.trial_count",
+    )
+
+
+def validate_execution_config(
+    execution: dict[str, Any],
+) -> None:
+    require_positive_number(
+        execution.get("target_fps"),
+        "execution.target_fps",
+    )
+    require_positive_integer(
+        execution.get("queue_capacity"),
+        "execution.queue_capacity",
+    )
+    require_non_negative_integer(
+        execution.get("warmup_frames"),
+        "execution.warmup_frames",
+    )
+    require_positive_integer(
+        execution.get("measured_frames"),
+        "execution.measured_frames",
+    )
+    require_positive_number(
+        execution.get("deadline_multiplier"),
+        "execution.deadline_multiplier",
+    )
+    require_non_empty_string(
+        execution.get("drop_policy"),
+        "execution.drop_policy",
+    )
+
+    if not isinstance(
+        execution.get("randomize_run_order"),
+        bool,
+    ):
+        raise ControlledIlluminationConfigError(
+            "execution.randomize_run_order must be boolean."
+        )
+
+    require_non_negative_integer(
+        execution.get("randomization_seed"),
+        "execution.randomization_seed",
+    )
+
+
+def validate_controlled_illumination_config(
+    config: dict[str, Any],
+) -> None:
+    if config.get("schema_version") != 1:
+        raise ControlledIlluminationConfigError(
+            "schema_version must be 1."
+        )
+
+    experiment = require_mapping(
+        config.get("experiment"),
+        "experiment",
+    )
+    require_non_empty_string(
+        experiment.get("name"),
+        "experiment.name",
+    )
+    require_non_empty_string(
+        experiment.get("protocol_path"),
+        "experiment.protocol_path",
+    )
+
+    phases = require_list(
+        config.get("phases"),
+        "phases",
+    )
+
+    phase_names: set[str] = set()
+
+    for index, phase_value in enumerate(phases):
+        phase = require_mapping(
+            phase_value,
+            f"phases[{index}]",
+        )
+        phase_name = require_non_empty_string(
+            phase.get("name"),
+            f"phases[{index}].name",
+        )
+
+        if phase_name in phase_names:
+            raise ControlledIlluminationConfigError(
+                f"Duplicate experiment phase: {phase_name}"
+            )
+
+        phase_names.add(phase_name)
+
+    missing_phases = REQUIRED_PHASES - phase_names
+
+    if missing_phases:
+        raise ControlledIlluminationConfigError(
+            "Missing experiment phases: "
+            f"{sorted(missing_phases)}"
+        )
+
+    validate_experiment_matrix(
+        require_mapping(
+            config.get("experiment_matrix"),
+            "experiment_matrix",
+        )
+    )
+
+    validate_execution_config(
+        require_mapping(
+            config.get("execution"),
+            "execution",
+        )
+    )
+
+    illuminance_measurement = require_mapping(
+        config.get("illuminance_measurement"),
+        "illuminance_measurement",
+    )
+
+    measurement_positions = set(
+        validate_unique_strings(
+            illuminance_measurement.get("positions"),
+            "illuminance_measurement.positions",
+        )
+    )
+
+    missing_positions = (
+        REQUIRED_ILLUMINANCE_POSITIONS
+        - measurement_positions
+    )
+
+    if missing_positions:
+        raise ControlledIlluminationConfigError(
+            "Missing illuminance measurement positions: "
+            f"{sorted(missing_positions)}"
+        )
+
+    camera_modes = require_mapping(
+        config.get("camera_modes"),
+        "camera_modes",
+    )
+
+    for required_mode in ("controlled", "operational"):
+        require_mapping(
+            camera_modes.get(required_mode),
+            f"camera_modes.{required_mode}",
+        )
+
+    required_metadata_fields = set(
+        validate_unique_strings(
+            config.get("required_run_metadata"),
+            "required_run_metadata",
+        )
+    )
+
+    missing_metadata_fields = (
+        REQUIRED_RUN_METADATA_FIELDS
+        - required_metadata_fields
+    )
+
+    if missing_metadata_fields:
+        raise ControlledIlluminationConfigError(
+            "Missing required run metadata fields: "
+            f"{sorted(missing_metadata_fields)}"
+        )
+
+    output = require_mapping(
+        config.get("output"),
+        "output",
+    )
+    require_non_empty_string(
+        output.get("directory"),
+        "output.directory",
+    )
+    require_non_empty_string(
+        output.get("metadata_file_name"),
+        "output.metadata_file_name",
+    )
+
+
+def load_controlled_illumination_config(
+    config_path: str | Path | None = None,
+) -> dict[str, Any]:
+    path = (
+        Path(config_path)
+        if config_path is not None
+        else DEFAULT_CONFIG_PATH
+    )
+
+    if not path.is_absolute():
+        path = PROJECT_ROOT / path
+
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"Controlled-illumination config not found: {path}"
+        )
+
+    try:
+        with path.open(
+            "r",
+            encoding="utf-8",
+        ) as config_file:
+            loaded_config = json.load(config_file)
+    except json.JSONDecodeError as error:
+        raise ControlledIlluminationConfigError(
+            f"Invalid JSON in {path}: {error}"
+        ) from error
+
+    config = require_mapping(
+        loaded_config,
+        "configuration root",
+    )
+
+    validate_controlled_illumination_config(config)
+
+    return config
+
+
+def main() -> None:
+    load_controlled_illumination_config()
+
+    print(
+        "Controlled-illumination configuration is valid."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/experiments/controlled_illumination_metadata.py
+++ b/benchmarks/experiments/controlled_illumination_metadata.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
 import json
 import math
+import os
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -48,6 +52,196 @@ REQUIRED_RUN_METADATA_FIELDS = {
 
 class ControlledIlluminationConfigError(ValueError):
     """Raised when the experiment configuration is invalid."""
+
+class ControlledIlluminationMetadataError(ValueError):
+    """Raised when controlled-illumination metadata is invalid."""
+
+
+def create_utc_timestamp() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def create_unique_identifier(
+    prefix: str,
+) -> str:
+    normalized_prefix = prefix.strip().lower().replace(
+        " ",
+        "-",
+    )
+
+    if not normalized_prefix:
+        raise ControlledIlluminationMetadataError(
+            "Identifier prefix must not be empty."
+        )
+
+    timestamp = datetime.now(timezone.utc).strftime(
+        "%Y%m%dT%H%M%S%fZ"
+    )
+    random_suffix = uuid4().hex[:8]
+
+    return (
+        f"{normalized_prefix}-"
+        f"{timestamp}-"
+        f"{random_suffix}"
+    )
+
+
+@dataclass(frozen=True)
+class ResolutionMetadata:
+    width: int
+    height: int
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.width, bool)
+            or not isinstance(self.width, int)
+            or self.width <= 0
+        ):
+            raise ControlledIlluminationMetadataError(
+                "Resolution width must be a positive integer."
+            )
+
+        if (
+            isinstance(self.height, bool)
+            or not isinstance(self.height, int)
+            or self.height <= 0
+        ):
+            raise ControlledIlluminationMetadataError(
+                "Resolution height must be a positive integer."
+            )
+
+
+@dataclass(frozen=True)
+class IlluminanceMeasurements:
+    centre_lux: float
+    top_left_lux: float
+    top_right_lux: float
+    bottom_left_lux: float
+    bottom_right_lux: float
+    measured_at_utc: str
+    lux_meter_model: str
+    lux_meter_range: str
+    lux_meter_resolution: str
+
+    def __post_init__(self) -> None:
+        for field_name, value in self.position_values.items():
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, (int, float))
+                or not math.isfinite(value)
+                or value < 0
+            ):
+                raise ControlledIlluminationMetadataError(
+                    f"{field_name} must be a non-negative "
+                    "finite number."
+                )
+
+        for field_name, value in (
+            ("measured_at_utc", self.measured_at_utc),
+            ("lux_meter_model", self.lux_meter_model),
+            ("lux_meter_range", self.lux_meter_range),
+            (
+                "lux_meter_resolution",
+                self.lux_meter_resolution,
+            ),
+        ):
+            if not isinstance(value, str) or not value.strip():
+                raise ControlledIlluminationMetadataError(
+                    f"{field_name} must be a non-empty string."
+                )
+
+    @property
+    def position_values(self) -> dict[str, float]:
+        return {
+            "centre_lux": float(self.centre_lux),
+            "top_left_lux": float(self.top_left_lux),
+            "top_right_lux": float(self.top_right_lux),
+            "bottom_left_lux": float(
+                self.bottom_left_lux
+            ),
+            "bottom_right_lux": float(
+                self.bottom_right_lux
+            ),
+        }
+
+    @property
+    def mean_lux(self) -> float:
+        values = list(self.position_values.values())
+        return sum(values) / len(values)
+
+    @property
+    def minimum_lux(self) -> float:
+        return min(self.position_values.values())
+
+    @property
+    def maximum_lux(self) -> float:
+        return max(self.position_values.values())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **self.position_values,
+            "mean_lux": self.mean_lux,
+            "minimum_lux": self.minimum_lux,
+            "maximum_lux": self.maximum_lux,
+            "measured_at_utc": self.measured_at_utc,
+            "lux_meter_model": self.lux_meter_model,
+            "lux_meter_range": self.lux_meter_range,
+            "lux_meter_resolution": (
+                self.lux_meter_resolution
+            ),
+        }
+
+
+@dataclass(frozen=True)
+class ControlledIlluminationRunMetadata:
+    experiment_id: str
+    run_id: str
+    collected_at_utc: str
+    git_commit_sha: str
+    phase: str
+    device_id: str
+    operating_system: str
+    platform: str
+    architecture: str
+    algorithm: str
+    algorithm_parameters: dict[str, Any]
+    resolution: ResolutionMetadata
+    trial_number: int
+    target_fps: float
+    frame_deadline_ms: float
+    target_illuminance_lux: float | None
+    measured_illuminance: IlluminanceMeasurements
+    incidence_angle_degrees: float
+    source_output_setting: str | float | int
+    camera_mode: str
+    camera_settings: dict[str, Any]
+    camera_to_target_distance_metres: float
+    light_to_target_distance_metres: float
+    input_scene_id: str
+    power_mode: str
+    clock_configuration: str
+    starting_temperature_celsius: float
+    ending_temperature_celsius: float
+    maximum_temperature_celsius: float
+    thermal_throttling_detected: bool
+    software_versions: dict[str, str]
+    dry_run: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        metadata = asdict(self)
+
+        metadata["resolution"] = asdict(
+            self.resolution
+        )
+        metadata["measured_illuminance"] = (
+            self.measured_illuminance.to_dict()
+        )
+
+        return metadata
 
 
 def require_mapping(
@@ -469,6 +663,434 @@ def load_controlled_illumination_config(
     validate_controlled_illumination_config(config)
 
     return config
+
+def validate_utc_timestamp(
+    value: str,
+    field_name: str,
+) -> None:
+    require_non_empty_string(value, field_name)
+
+    try:
+        parsed_timestamp = datetime.fromisoformat(
+            value.replace("Z", "+00:00")
+        )
+    except ValueError as error:
+        raise ControlledIlluminationMetadataError(
+            f"{field_name} must be a valid ISO 8601 timestamp."
+        ) from error
+
+    if (
+        parsed_timestamp.tzinfo is None
+        or parsed_timestamp.utcoffset()
+        != timezone.utc.utcoffset(parsed_timestamp)
+    ):
+        raise ControlledIlluminationMetadataError(
+            f"{field_name} must use UTC."
+        )
+
+
+def validate_safe_identifier(
+    value: str,
+    field_name: str,
+) -> None:
+    require_non_empty_string(value, field_name)
+
+    if (
+        value in {".", ".."}
+        or "/" in value
+        or "\\" in value
+    ):
+        raise ControlledIlluminationMetadataError(
+            f"{field_name} contains invalid path characters."
+        )
+
+
+def validate_run_metadata(
+    metadata: ControlledIlluminationRunMetadata,
+    config: dict[str, Any],
+) -> None:
+    validate_controlled_illumination_config(config)
+
+    validate_safe_identifier(
+        metadata.experiment_id,
+        "experiment_id",
+    )
+    validate_safe_identifier(
+        metadata.run_id,
+        "run_id",
+    )
+    validate_utc_timestamp(
+        metadata.collected_at_utc,
+        "collected_at_utc",
+    )
+
+    required_string_fields = (
+        "device_id",
+        "operating_system",
+        "platform",
+        "architecture",
+        "algorithm",
+        "camera_mode",
+        "input_scene_id",
+        "power_mode",
+        "clock_configuration",
+    )
+
+    for field_name in required_string_fields:
+        require_non_empty_string(
+            getattr(metadata, field_name),
+            field_name,
+        )
+
+    git_commit_sha = metadata.git_commit_sha.lower()
+
+    if (
+        len(git_commit_sha) != 40
+        or any(
+            character not in "0123456789abcdef"
+            for character in git_commit_sha
+        )
+    ):
+        raise ControlledIlluminationMetadataError(
+            "git_commit_sha must contain a full "
+            "40-character hexadecimal commit SHA."
+        )
+
+    phase_names = {
+        phase["name"]
+        for phase in config["phases"]
+    }
+
+    if metadata.phase not in phase_names:
+        raise ControlledIlluminationMetadataError(
+            f"Unsupported experiment phase: {metadata.phase}"
+        )
+
+    matrix = config["experiment_matrix"]
+
+    for field_name, value, allowed_values in (
+        (
+            "platform",
+            metadata.platform,
+            matrix["platforms"],
+        ),
+        (
+            "architecture",
+            metadata.architecture,
+            matrix["architectures"],
+        ),
+        (
+            "algorithm",
+            metadata.algorithm,
+            matrix["algorithms"],
+        ),
+    ):
+        if value not in allowed_values:
+            raise ControlledIlluminationMetadataError(
+                f"Unsupported {field_name}: {value}"
+            )
+
+    resolution_pair = (
+        metadata.resolution.width,
+        metadata.resolution.height,
+    )
+
+    allowed_resolutions = {
+        (
+            resolution["width"],
+            resolution["height"],
+        )
+        for resolution in matrix["resolutions"]
+    }
+
+    if resolution_pair not in allowed_resolutions:
+        raise ControlledIlluminationMetadataError(
+            "Unsupported resolution: "
+            f"{resolution_pair[0]}x{resolution_pair[1]}"
+        )
+
+    trial_count = matrix["trial_count"]
+
+    if (
+        isinstance(metadata.trial_number, bool)
+        or not isinstance(metadata.trial_number, int)
+        or metadata.trial_number < 1
+        or metadata.trial_number > trial_count
+    ):
+        raise ControlledIlluminationMetadataError(
+            "trial_number must be between "
+            f"1 and {trial_count}."
+        )
+
+    allowed_angles = matrix[
+        "incidence_angles_degrees"
+    ]
+
+    if not any(
+        math.isclose(
+            metadata.incidence_angle_degrees,
+            allowed_angle,
+            abs_tol=1e-9,
+        )
+        for allowed_angle in allowed_angles
+    ):
+        raise ControlledIlluminationMetadataError(
+            "Unsupported incidence angle: "
+            f"{metadata.incidence_angle_degrees}"
+        )
+
+    target_levels = matrix[
+        "target_illuminance_levels_lux"
+    ]
+
+    if metadata.phase == "constant_lux":
+        if metadata.target_illuminance_lux is None:
+            raise ControlledIlluminationMetadataError(
+                "constant_lux runs require "
+                "target_illuminance_lux."
+            )
+
+        if not any(
+            math.isclose(
+                metadata.target_illuminance_lux,
+                target_level,
+                abs_tol=1e-9,
+            )
+            for target_level in target_levels
+        ):
+            raise ControlledIlluminationMetadataError(
+                "Unsupported target illuminance: "
+                f"{metadata.target_illuminance_lux}"
+            )
+
+    if (
+        metadata.phase == "constant_source"
+        and metadata.target_illuminance_lux is not None
+    ):
+        raise ControlledIlluminationMetadataError(
+            "constant_source runs must not define "
+            "target_illuminance_lux."
+        )
+
+    execution = config["execution"]
+
+    if not math.isclose(
+        metadata.target_fps,
+        execution["target_fps"],
+        abs_tol=1e-9,
+    ):
+        raise ControlledIlluminationMetadataError(
+            "target_fps does not match the experiment config."
+        )
+
+    expected_deadline_ms = (
+        1000.0
+        / execution["target_fps"]
+        * execution["deadline_multiplier"]
+    )
+
+    if not math.isclose(
+        metadata.frame_deadline_ms,
+        expected_deadline_ms,
+        abs_tol=0.01,
+    ):
+        raise ControlledIlluminationMetadataError(
+            "frame_deadline_ms does not match "
+            "the configured frame deadline."
+        )
+
+    if not isinstance(
+        metadata.algorithm_parameters,
+        dict,
+    ):
+        raise ControlledIlluminationMetadataError(
+            "algorithm_parameters must be an object."
+        )
+
+    camera_modes = config["camera_modes"]
+
+    if metadata.camera_mode not in camera_modes:
+        raise ControlledIlluminationMetadataError(
+            f"Unsupported camera mode: {metadata.camera_mode}"
+        )
+
+    if (
+        not isinstance(metadata.camera_settings, dict)
+        or not metadata.camera_settings
+    ):
+        raise ControlledIlluminationMetadataError(
+            "camera_settings must be a non-empty object."
+        )
+
+    required_camera_settings = set(
+        camera_modes[metadata.camera_mode].get(
+            "required_settings",
+            [],
+        )
+    )
+
+    missing_camera_settings = (
+        required_camera_settings
+        - set(metadata.camera_settings)
+    )
+
+    if missing_camera_settings:
+        raise ControlledIlluminationMetadataError(
+            "Missing camera settings: "
+            f"{sorted(missing_camera_settings)}"
+        )
+
+    for field_name, distance in (
+        (
+            "camera_to_target_distance_metres",
+            metadata.camera_to_target_distance_metres,
+        ),
+        (
+            "light_to_target_distance_metres",
+            metadata.light_to_target_distance_metres,
+        ),
+    ):
+        require_positive_number(
+            distance,
+            field_name,
+        )
+
+    temperatures = {
+        "starting_temperature_celsius": (
+            metadata.starting_temperature_celsius
+        ),
+        "ending_temperature_celsius": (
+            metadata.ending_temperature_celsius
+        ),
+        "maximum_temperature_celsius": (
+            metadata.maximum_temperature_celsius
+        ),
+    }
+
+    for field_name, temperature in temperatures.items():
+        if (
+            isinstance(temperature, bool)
+            or not isinstance(temperature, (int, float))
+            or not math.isfinite(temperature)
+        ):
+            raise ControlledIlluminationMetadataError(
+                f"{field_name} must be a finite number."
+            )
+
+    if metadata.maximum_temperature_celsius < max(
+        metadata.starting_temperature_celsius,
+        metadata.ending_temperature_celsius,
+    ):
+        raise ControlledIlluminationMetadataError(
+            "maximum_temperature_celsius cannot be lower "
+            "than the starting or ending temperature."
+        )
+
+    if not isinstance(
+        metadata.thermal_throttling_detected,
+        bool,
+    ):
+        raise ControlledIlluminationMetadataError(
+            "thermal_throttling_detected must be boolean."
+        )
+
+    source_output = metadata.source_output_setting
+
+    if isinstance(source_output, str):
+        require_non_empty_string(
+            source_output,
+            "source_output_setting",
+        )
+    elif (
+        isinstance(source_output, bool)
+        or not isinstance(source_output, (int, float))
+        or not math.isfinite(source_output)
+        or source_output < 0
+    ):
+        raise ControlledIlluminationMetadataError(
+            "source_output_setting must be a non-negative "
+            "number or a non-empty string."
+        )
+
+    if (
+        not isinstance(metadata.software_versions, dict)
+        or not metadata.software_versions
+    ):
+        raise ControlledIlluminationMetadataError(
+            "software_versions must be a non-empty object."
+        )
+
+
+def save_run_metadata_atomic(
+    metadata: ControlledIlluminationRunMetadata,
+    config: dict[str, Any] | None = None,
+    output_path: str | Path | None = None,
+) -> Path:
+    active_config = (
+        config
+        if config is not None
+        else load_controlled_illumination_config()
+    )
+
+    validate_run_metadata(
+        metadata,
+        active_config,
+    )
+
+    if output_path is None:
+        metadata_path = (
+            PROJECT_ROOT
+            / active_config["output"]["directory"]
+            / metadata.platform
+            / metadata.experiment_id
+            / metadata.run_id
+            / active_config["output"][
+                "metadata_file_name"
+            ]
+        )
+    else:
+        metadata_path = Path(output_path)
+
+        if not metadata_path.is_absolute():
+            metadata_path = (
+                PROJECT_ROOT / metadata_path
+            )
+
+    metadata_path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    temporary_path = metadata_path.with_name(
+        f".{metadata_path.name}."
+        f"{uuid4().hex}.tmp"
+    )
+
+    try:
+        with temporary_path.open(
+            "w",
+            encoding="utf-8",
+        ) as output_file:
+            json.dump(
+                metadata.to_dict(),
+                output_file,
+                indent=2,
+                ensure_ascii=False,
+            )
+            output_file.write("\n")
+            output_file.flush()
+            os.fsync(output_file.fileno())
+
+        os.replace(
+            temporary_path,
+            metadata_path,
+        )
+    finally:
+        temporary_path.unlink(
+            missing_ok=True,
+        )
+
+    return metadata_path
 
 
 def main() -> None:

--- a/benchmarks/experiments/controlled_illumination_metadata.py
+++ b/benchmarks/experiments/controlled_illumination_metadata.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, fields
 from datetime import datetime, timezone
 import json
 import math
@@ -720,8 +720,8 @@ def validate_run_metadata(
         "run_id",
     )
     validate_utc_timestamp(
-        metadata.collected_at_utc,
-        "collected_at_utc",
+        metadata.measured_illuminance.measured_at_utc,
+        "measured_illuminance.measured_at_utc",
     )
 
     required_string_fields = (
@@ -1091,6 +1091,232 @@ def save_run_metadata_atomic(
         )
 
     return metadata_path
+
+def require_metadata_mapping(
+    value: Any,
+    field_name: str,
+) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ControlledIlluminationMetadataError(
+            f"{field_name} must be an object."
+        )
+
+    return value
+
+
+def require_metadata_value(
+    mapping: dict[str, Any],
+    field_name: str,
+    parent_name: str,
+) -> Any:
+    if field_name not in mapping:
+        raise ControlledIlluminationMetadataError(
+            f"Missing metadata field: "
+            f"{parent_name}.{field_name}"
+        )
+
+    return mapping[field_name]
+
+
+def run_metadata_from_dict(
+    metadata_value: Any,
+    config: dict[str, Any] | None = None,
+) -> ControlledIlluminationRunMetadata:
+    metadata_data = require_metadata_mapping(
+        metadata_value,
+        "metadata root",
+    )
+
+    resolution_data = require_metadata_mapping(
+        require_metadata_value(
+            metadata_data,
+            "resolution",
+            "metadata",
+        ),
+        "metadata.resolution",
+    )
+
+    illuminance_data = require_metadata_mapping(
+        require_metadata_value(
+            metadata_data,
+            "measured_illuminance",
+            "metadata",
+        ),
+        "metadata.measured_illuminance",
+    )
+
+    resolution = ResolutionMetadata(
+        width=require_metadata_value(
+            resolution_data,
+            "width",
+            "metadata.resolution",
+        ),
+        height=require_metadata_value(
+            resolution_data,
+            "height",
+            "metadata.resolution",
+        ),
+    )
+
+    illuminance = IlluminanceMeasurements(
+        centre_lux=require_metadata_value(
+            illuminance_data,
+            "centre_lux",
+            "metadata.measured_illuminance",
+        ),
+        top_left_lux=require_metadata_value(
+            illuminance_data,
+            "top_left_lux",
+            "metadata.measured_illuminance",
+        ),
+        top_right_lux=require_metadata_value(
+            illuminance_data,
+            "top_right_lux",
+            "metadata.measured_illuminance",
+        ),
+        bottom_left_lux=require_metadata_value(
+            illuminance_data,
+            "bottom_left_lux",
+            "metadata.measured_illuminance",
+        ),
+        bottom_right_lux=require_metadata_value(
+            illuminance_data,
+            "bottom_right_lux",
+            "metadata.measured_illuminance",
+        ),
+        measured_at_utc=require_metadata_value(
+            illuminance_data,
+            "measured_at_utc",
+            "metadata.measured_illuminance",
+        ),
+        lux_meter_model=require_metadata_value(
+            illuminance_data,
+            "lux_meter_model",
+            "metadata.measured_illuminance",
+        ),
+        lux_meter_range=require_metadata_value(
+            illuminance_data,
+            "lux_meter_range",
+            "metadata.measured_illuminance",
+        ),
+        lux_meter_resolution=require_metadata_value(
+            illuminance_data,
+            "lux_meter_resolution",
+            "metadata.measured_illuminance",
+        ),
+    )
+
+    expected_summaries = {
+        "mean_lux": illuminance.mean_lux,
+        "minimum_lux": illuminance.minimum_lux,
+        "maximum_lux": illuminance.maximum_lux,
+    }
+
+    for field_name, expected_value in (
+        expected_summaries.items()
+    ):
+        stored_value = require_metadata_value(
+            illuminance_data,
+            field_name,
+            "metadata.measured_illuminance",
+        )
+
+        if (
+            isinstance(stored_value, bool)
+            or not isinstance(
+                stored_value,
+                (int, float),
+            )
+            or not math.isfinite(stored_value)
+            or not math.isclose(
+                stored_value,
+                expected_value,
+                abs_tol=1e-9,
+            )
+        ):
+            raise ControlledIlluminationMetadataError(
+                "Stored illuminance summary does not "
+                f"match measured values: {field_name}"
+            )
+
+    metadata_arguments = dict(metadata_data)
+    metadata_arguments["resolution"] = resolution
+    metadata_arguments[
+        "measured_illuminance"
+    ] = illuminance
+
+    supported_fields = {
+        metadata_field.name
+        for metadata_field in fields(
+            ControlledIlluminationRunMetadata
+        )
+    }
+
+    unexpected_fields = (
+        set(metadata_arguments)
+        - supported_fields
+    )
+
+    if unexpected_fields:
+        raise ControlledIlluminationMetadataError(
+            "Unexpected metadata fields: "
+            f"{sorted(unexpected_fields)}"
+        )
+
+    try:
+        metadata = ControlledIlluminationRunMetadata(
+            **metadata_arguments
+        )
+    except TypeError as error:
+        raise ControlledIlluminationMetadataError(
+            f"Invalid run metadata structure: {error}"
+        ) from error
+
+    active_config = (
+        config
+        if config is not None
+        else load_controlled_illumination_config()
+    )
+
+    validate_run_metadata(
+        metadata,
+        active_config,
+    )
+
+    return metadata
+
+
+def load_run_metadata(
+    metadata_path: str | Path,
+    config: dict[str, Any] | None = None,
+) -> ControlledIlluminationRunMetadata:
+    path = Path(metadata_path)
+
+    if not path.is_absolute():
+        path = PROJECT_ROOT / path
+
+    if not path.is_file():
+        raise FileNotFoundError(
+            f"Run metadata file not found: {path}"
+        )
+
+    try:
+        with path.open(
+            "r",
+            encoding="utf-8",
+        ) as metadata_file:
+            metadata_value = json.load(
+                metadata_file
+            )
+    except json.JSONDecodeError as error:
+        raise ControlledIlluminationMetadataError(
+            f"Invalid metadata JSON in {path}: {error}"
+        ) from error
+
+    return run_metadata_from_dict(
+        metadata_value,
+        config=config,
+    )
 
 
 def main() -> None:

--- a/benchmarks/experiments/controlled_illumination_metadata.py
+++ b/benchmarks/experiments/controlled_illumination_metadata.py
@@ -746,12 +746,14 @@ def validate_run_metadata(
             field_name,
         )
 
-    git_commit_sha = metadata.git_commit_sha.lower()
-
     if not isinstance(metadata.git_commit_sha, str):
         raise ControlledIlluminationMetadataError(
             "git_commit_sha must be a string."
         )
+
+    git_commit_sha = metadata.git_commit_sha.lower()
+
+
 
     if (
         len(git_commit_sha) != 40

--- a/benchmarks/experiments/controlled_illumination_metadata.py
+++ b/benchmarks/experiments/controlled_illumination_metadata.py
@@ -703,7 +703,21 @@ def validate_safe_identifier(
         raise ControlledIlluminationMetadataError(
             f"{field_name} contains invalid path characters."
         )
+    
+def require_finite_metadata_number(
+    value: Any,
+    field_name: str,
+) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+    ):
+        raise ControlledIlluminationMetadataError(
+            f"{field_name} must be a finite number."
+        )
 
+    return float(value)
 
 def validate_run_metadata(
     metadata: ControlledIlluminationRunMetadata,
@@ -837,9 +851,16 @@ def validate_run_metadata(
         "incidence_angles_degrees"
     ]
 
+    incidence_angle_degrees = (
+        require_finite_metadata_number(
+            metadata.incidence_angle_degrees,
+            "incidence_angle_degrees",
+        )
+    )
+
     if not any(
         math.isclose(
-            metadata.incidence_angle_degrees,
+            incidence_angle_degrees,
             allowed_angle,
             abs_tol=1e-9,
         )
@@ -860,10 +881,16 @@ def validate_run_metadata(
                 "constant_lux runs require "
                 "target_illuminance_lux."
             )
+        target_illuminance_lux = (
+            require_finite_metadata_number(
+                metadata.target_illuminance_lux,
+                "target_illuminance_lux",
+            )
+        )
 
         if not any(
             math.isclose(
-                metadata.target_illuminance_lux,
+                target_illuminance_lux,
                 target_level,
                 abs_tol=1e-9,
             )
@@ -885,8 +912,13 @@ def validate_run_metadata(
 
     execution = config["execution"]
 
-    if not math.isclose(
+    target_fps = require_finite_metadata_number(
         metadata.target_fps,
+        "target_fps",
+    )
+
+    if not math.isclose(
+        target_fps,
         execution["target_fps"],
         abs_tol=1e-9,
     ):
@@ -900,8 +932,13 @@ def validate_run_metadata(
         * execution["deadline_multiplier"]
     )
 
-    if not math.isclose(
+    frame_deadline_ms = require_finite_metadata_number(
         metadata.frame_deadline_ms,
+        "frame_deadline_ms",
+    )
+    
+    if not math.isclose(
+        frame_deadline_ms,
         expected_deadline_ms,
         abs_tol=0.01,
     ):

--- a/benchmarks/experiments/controlled_illumination_metadata.py
+++ b/benchmarks/experiments/controlled_illumination_metadata.py
@@ -703,7 +703,7 @@ def validate_safe_identifier(
         raise ControlledIlluminationMetadataError(
             f"{field_name} contains invalid path characters."
         )
-    
+
 def require_finite_metadata_number(
     value: Any,
     field_name: str,
@@ -935,7 +935,7 @@ def validate_run_metadata(
         metadata.frame_deadline_ms,
         "frame_deadline_ms",
     )
-    
+
     if not math.isclose(
         frame_deadline_ms,
         expected_deadline_ms,

--- a/benchmarks/experiments/controlled_illumination_metadata.py
+++ b/benchmarks/experiments/controlled_illumination_metadata.py
@@ -720,6 +720,10 @@ def validate_run_metadata(
         "run_id",
     )
     validate_utc_timestamp(
+        metadata.collected_at_utc,
+        "collected_at_utc",
+    )
+    validate_utc_timestamp(
         metadata.measured_illuminance.measured_at_utc,
         "measured_illuminance.measured_at_utc",
     )
@@ -743,6 +747,11 @@ def validate_run_metadata(
         )
 
     git_commit_sha = metadata.git_commit_sha.lower()
+
+    if not isinstance(metadata.git_commit_sha, str):
+        raise ControlledIlluminationMetadataError(
+            "git_commit_sha must be a string."
+        )
 
     if (
         len(git_commit_sha) != 40

--- a/benchmarks/experiments/generate_dry_run_metadata.py
+++ b/benchmarks/experiments/generate_dry_run_metadata.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import platform as platform_module
+import subprocess
+from typing import Any
+
+from benchmarks.experiments.controlled_illumination_metadata import (
+    PROJECT_ROOT,
+    ControlledIlluminationRunMetadata,
+    IlluminanceMeasurements,
+    ResolutionMetadata,
+    create_unique_identifier,
+    create_utc_timestamp,
+    load_controlled_illumination_config,
+    save_run_metadata_atomic,
+    validate_run_metadata,
+)
+
+
+def read_git_commit_sha() -> str:
+    try:
+        completed_process = subprocess.run(
+            [
+                "git",
+                "rev-parse",
+                "HEAD",
+            ],
+            cwd=PROJECT_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (
+        FileNotFoundError,
+        subprocess.CalledProcessError,
+    ) as error:
+        raise RuntimeError(
+            "Unable to determine the Git commit SHA."
+        ) from error
+
+    commit_sha = completed_process.stdout.strip()
+
+    if not commit_sha:
+        raise RuntimeError(
+            "Git returned an empty commit SHA."
+        )
+
+    return commit_sha
+
+
+def build_dry_run_metadata(
+    config: dict[str, Any],
+    git_commit_sha: str,
+) -> ControlledIlluminationRunMetadata:
+    matrix = config["experiment_matrix"]
+    execution = config["execution"]
+
+    resolution_config = matrix["resolutions"][0]
+    target_illuminance_lux = float(
+        matrix["target_illuminance_levels_lux"][0]
+    )
+    incidence_angle_degrees = float(
+        matrix["incidence_angles_degrees"][0]
+    )
+
+    collected_at_utc = create_utc_timestamp()
+
+    illuminance = IlluminanceMeasurements(
+        centre_lux=target_illuminance_lux,
+        top_left_lux=target_illuminance_lux,
+        top_right_lux=target_illuminance_lux,
+        bottom_left_lux=target_illuminance_lux,
+        bottom_right_lux=target_illuminance_lux,
+        measured_at_utc=collected_at_utc,
+        lux_meter_model="dry-run-meter",
+        lux_meter_range="dry-run",
+        lux_meter_resolution="dry-run",
+    )
+
+    target_fps = float(
+        execution["target_fps"]
+    )
+    frame_deadline_ms = (
+        1000.0
+        / target_fps
+        * execution["deadline_multiplier"]
+    )
+
+    metadata = ControlledIlluminationRunMetadata(
+        experiment_id=create_unique_identifier(
+            "controlled-illumination"
+        ),
+        run_id=create_unique_identifier("run"),
+        collected_at_utc=collected_at_utc,
+        git_commit_sha=git_commit_sha,
+        phase="constant_lux",
+        device_id=(
+            platform_module.node()
+            or "dry-run-device"
+        ),
+        operating_system=platform_module.platform(),
+        platform="desktop",
+        architecture="pure_python",
+        algorithm="original",
+        algorithm_parameters={},
+        resolution=ResolutionMetadata(
+            width=resolution_config["width"],
+            height=resolution_config["height"],
+        ),
+        trial_number=1,
+        target_fps=target_fps,
+        frame_deadline_ms=frame_deadline_ms,
+        target_illuminance_lux=(
+            target_illuminance_lux
+        ),
+        measured_illuminance=illuminance,
+        incidence_angle_degrees=(
+            incidence_angle_degrees
+        ),
+        source_output_setting=(
+            "dry-run-adjusted-to-target-lux"
+        ),
+        camera_mode="controlled",
+        camera_settings={
+            "exposure_time": "dry-run",
+            "sensor_gain_or_iso": "dry-run",
+            "white_balance": "dry-run",
+            "focus": "dry-run",
+            "frame_rate": target_fps,
+            "resolution": (
+                f"{resolution_config['width']}x"
+                f"{resolution_config['height']}"
+            ),
+            "lens": "dry-run",
+            "aperture": None,
+        },
+        camera_to_target_distance_metres=1.0,
+        light_to_target_distance_metres=1.0,
+        input_scene_id="dry-run-scene",
+        power_mode="dry-run",
+        clock_configuration="dry-run",
+        starting_temperature_celsius=25.0,
+        ending_temperature_celsius=25.0,
+        maximum_temperature_celsius=25.0,
+        thermal_throttling_detected=False,
+        software_versions={
+            "python": (
+                platform_module.python_version()
+            ),
+            "python_implementation": (
+                platform_module.python_implementation()
+            ),
+            "metadata_schema": str(
+                config["schema_version"]
+            ),
+        },
+        dry_run=True,
+    )
+
+    validate_run_metadata(
+        metadata,
+        config,
+    )
+
+    return metadata
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate validated controlled-illumination "
+            "dry-run metadata."
+        )
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help=(
+            "Optional output JSON path. The configured "
+            "results directory is used by default."
+        ),
+    )
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    arguments = parse_arguments()
+    config = load_controlled_illumination_config()
+
+    metadata = build_dry_run_metadata(
+        config,
+        read_git_commit_sha(),
+    )
+
+    output_path = save_run_metadata_atomic(
+        metadata,
+        config=config,
+        output_path=arguments.output,
+    )
+
+    print(
+        "Controlled-illumination dry run passed."
+    )
+    print(
+        f"Experiment ID: {metadata.experiment_id}"
+    )
+    print(
+        f"Run ID: {metadata.run_id}"
+    )
+    print(
+        f"Metadata created: {output_path}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/experiments/tests/test_controlled_illumination_metadata.py
+++ b/benchmarks/experiments/tests/test_controlled_illumination_metadata.py
@@ -11,14 +11,43 @@ from benchmarks.experiments.controlled_illumination_metadata import (
     ResolutionMetadata,
     create_unique_identifier,
     load_controlled_illumination_config,
+    load_run_metadata,
     save_run_metadata_atomic,
     validate_run_metadata,
+)
+
+from benchmarks.experiments.generate_dry_run_metadata import (
+    build_dry_run_metadata,
 )
 
 
 class ControlledIlluminationMetadataTests(
     unittest.TestCase
 ):
+    def test_dry_run_metadata_is_valid(
+        self,
+    ) -> None:
+        metadata = build_dry_run_metadata(
+            self.config,
+            git_commit_sha="b" * 40,
+        )
+
+        self.assertTrue(
+            metadata.dry_run
+        )
+        self.assertEqual(
+            metadata.phase,
+            "constant_lux",
+        )
+        self.assertEqual(
+            metadata.platform,
+            "desktop",
+        )
+
+        validate_run_metadata(
+            metadata,
+            self.config,
+        )
     def setUp(self) -> None:
         self.config = (
             load_controlled_illumination_config()
@@ -177,6 +206,16 @@ class ControlledIlluminationMetadataTests(
             self.assertEqual(
                 temporary_files,
                 [],
+            )
+
+            loaded_metadata = load_run_metadata(
+                output_path,
+                config=self.config,
+            )
+
+            self.assertEqual(
+                loaded_metadata,
+                self.metadata,
             )
 
     def test_invalid_trial_number_is_rejected(

--- a/benchmarks/experiments/tests/test_controlled_illumination_metadata.py
+++ b/benchmarks/experiments/tests/test_controlled_illumination_metadata.py
@@ -1,0 +1,292 @@
+from dataclasses import replace
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from benchmarks.experiments.controlled_illumination_metadata import (
+    ControlledIlluminationMetadataError,
+    ControlledIlluminationRunMetadata,
+    IlluminanceMeasurements,
+    ResolutionMetadata,
+    create_unique_identifier,
+    load_controlled_illumination_config,
+    save_run_metadata_atomic,
+    validate_run_metadata,
+)
+
+
+class ControlledIlluminationMetadataTests(
+    unittest.TestCase
+):
+    def setUp(self) -> None:
+        self.config = (
+            load_controlled_illumination_config()
+        )
+
+        self.illuminance = IlluminanceMeasurements(
+            centre_lux=50.0,
+            top_left_lux=49.0,
+            top_right_lux=51.0,
+            bottom_left_lux=50.0,
+            bottom_right_lux=50.0,
+            measured_at_utc=(
+                "2026-08-21T09:00:00Z"
+            ),
+            lux_meter_model="dry-run-meter",
+            lux_meter_range="0-2000 lux",
+            lux_meter_resolution="1 lux",
+        )
+
+        self.metadata = (
+            ControlledIlluminationRunMetadata(
+                experiment_id="experiment-test",
+                run_id="run-test",
+                collected_at_utc=(
+                    "2026-08-21T09:01:00Z"
+                ),
+                git_commit_sha="a" * 40,
+                phase="constant_lux",
+                device_id="desktop-test",
+                operating_system="Windows 11",
+                platform="desktop",
+                architecture="pure_python",
+                algorithm="gamma_correction",
+                algorithm_parameters={
+                    "gamma_value": 0.6,
+                },
+                resolution=ResolutionMetadata(
+                    width=640,
+                    height=480,
+                ),
+                trial_number=1,
+                target_fps=30.0,
+                frame_deadline_ms=(
+                    1000.0 / 30.0
+                ),
+                target_illuminance_lux=50.0,
+                measured_illuminance=(
+                    self.illuminance
+                ),
+                incidence_angle_degrees=30.0,
+                source_output_setting=50.0,
+                camera_mode="controlled",
+                camera_settings={
+                    "exposure_time": "1/60 s",
+                    "sensor_gain_or_iso": 100,
+                    "white_balance": (
+                        "manual_4500k"
+                    ),
+                    "focus": "manual",
+                    "frame_rate": 30.0,
+                    "resolution": "640x480",
+                    "lens": "dry-run-lens",
+                    "aperture": None,
+                },
+                camera_to_target_distance_metres=(
+                    1.5
+                ),
+                light_to_target_distance_metres=(
+                    2.0
+                ),
+                input_scene_id="dry-run-scene",
+                power_mode="balanced",
+                clock_configuration="default",
+                starting_temperature_celsius=45.0,
+                ending_temperature_celsius=48.0,
+                maximum_temperature_celsius=50.0,
+                thermal_throttling_detected=False,
+                software_versions={
+                    "python": "3.13.12",
+                    "opencv": "4.11.0",
+                },
+                dry_run=True,
+            )
+        )
+
+    def test_valid_metadata_passes_validation(
+        self,
+    ) -> None:
+        validate_run_metadata(
+            self.metadata,
+            self.config,
+        )
+
+    def test_illuminance_summary_is_calculated(
+        self,
+    ) -> None:
+        self.assertEqual(
+            self.illuminance.mean_lux,
+            50.0,
+        )
+        self.assertEqual(
+            self.illuminance.minimum_lux,
+            49.0,
+        )
+        self.assertEqual(
+            self.illuminance.maximum_lux,
+            51.0,
+        )
+
+    def test_metadata_is_saved_atomically(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output_path = (
+                Path(directory)
+                / "run_metadata.json"
+            )
+
+            saved_path = save_run_metadata_atomic(
+                self.metadata,
+                config=self.config,
+                output_path=output_path,
+            )
+
+            self.assertEqual(
+                saved_path,
+                output_path,
+            )
+            self.assertTrue(
+                output_path.is_file()
+            )
+
+            with output_path.open(
+                "r",
+                encoding="utf-8",
+            ) as metadata_file:
+                saved_metadata = json.load(
+                    metadata_file
+                )
+
+            self.assertEqual(
+                saved_metadata["experiment_id"],
+                "experiment-test",
+            )
+            self.assertEqual(
+                saved_metadata[
+                    "measured_illuminance"
+                ]["mean_lux"],
+                50.0,
+            )
+
+            temporary_files = list(
+                Path(directory).glob("*.tmp")
+            )
+
+            self.assertEqual(
+                temporary_files,
+                [],
+            )
+
+    def test_invalid_trial_number_is_rejected(
+        self,
+    ) -> None:
+        invalid_metadata = replace(
+            self.metadata,
+            trial_number=6,
+        )
+
+        with self.assertRaises(
+            ControlledIlluminationMetadataError
+        ):
+            validate_run_metadata(
+                invalid_metadata,
+                self.config,
+            )
+
+    def test_invalid_incidence_angle_is_rejected(
+        self,
+    ) -> None:
+        invalid_metadata = replace(
+            self.metadata,
+            incidence_angle_degrees=45.0,
+        )
+
+        with self.assertRaises(
+            ControlledIlluminationMetadataError
+        ):
+            validate_run_metadata(
+                invalid_metadata,
+                self.config,
+            )
+
+    def test_constant_source_rejects_target_lux(
+        self,
+    ) -> None:
+        invalid_metadata = replace(
+            self.metadata,
+            phase="constant_source",
+            target_illuminance_lux=50.0,
+        )
+
+        with self.assertRaises(
+            ControlledIlluminationMetadataError
+        ):
+            validate_run_metadata(
+                invalid_metadata,
+                self.config,
+            )
+
+    def test_missing_camera_setting_is_rejected(
+        self,
+    ) -> None:
+        camera_settings = dict(
+            self.metadata.camera_settings
+        )
+        camera_settings.pop("lens")
+
+        invalid_metadata = replace(
+            self.metadata,
+            camera_settings=camera_settings,
+        )
+
+        with self.assertRaises(
+            ControlledIlluminationMetadataError
+        ):
+            validate_run_metadata(
+                invalid_metadata,
+                self.config,
+            )
+
+    def test_negative_lux_is_rejected(
+        self,
+    ) -> None:
+        with self.assertRaises(
+            ControlledIlluminationMetadataError
+        ):
+            IlluminanceMeasurements(
+                centre_lux=-1.0,
+                top_left_lux=0.0,
+                top_right_lux=0.0,
+                bottom_left_lux=0.0,
+                bottom_right_lux=0.0,
+                measured_at_utc=(
+                    "2026-08-21T09:00:00Z"
+                ),
+                lux_meter_model="test-meter",
+                lux_meter_range="0-2000 lux",
+                lux_meter_resolution="1 lux",
+            )
+
+    def test_generated_identifiers_are_unique(
+        self,
+    ) -> None:
+        first_identifier = (
+            create_unique_identifier("run")
+        )
+        second_identifier = (
+            create_unique_identifier("run")
+        )
+
+        self.assertNotEqual(
+            first_identifier,
+            second_identifier,
+        )
+        self.assertTrue(
+            first_identifier.startswith("run-")
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/experiments/tests/test_controlled_illumination_metadata.py
+++ b/benchmarks/experiments/tests/test_controlled_illumination_metadata.py
@@ -25,7 +25,7 @@ class ControlledIlluminationMetadataTests(
     unittest.TestCase
 ):
     def test_dry_run_metadata_is_valid(
-        self,
+            self,
     ) -> None:
         metadata = build_dry_run_metadata(
             self.config,
@@ -48,6 +48,7 @@ class ControlledIlluminationMetadataTests(
             metadata,
             self.config,
         )
+
     def setUp(self) -> None:
         self.config = (
             load_controlled_illumination_config()
@@ -91,7 +92,7 @@ class ControlledIlluminationMetadataTests(
                 trial_number=1,
                 target_fps=30.0,
                 frame_deadline_ms=(
-                    1000.0 / 30.0
+                        1000.0 / 30.0
                 ),
                 target_illuminance_lux=50.0,
                 measured_illuminance=(
@@ -134,7 +135,7 @@ class ControlledIlluminationMetadataTests(
         )
 
     def test_valid_metadata_passes_validation(
-        self,
+            self,
     ) -> None:
         validate_run_metadata(
             self.metadata,
@@ -142,7 +143,7 @@ class ControlledIlluminationMetadataTests(
         )
 
     def test_illuminance_summary_is_calculated(
-        self,
+            self,
     ) -> None:
         self.assertEqual(
             self.illuminance.mean_lux,
@@ -158,12 +159,12 @@ class ControlledIlluminationMetadataTests(
         )
 
     def test_metadata_is_saved_atomically(
-        self,
+            self,
     ) -> None:
         with tempfile.TemporaryDirectory() as directory:
             output_path = (
-                Path(directory)
-                / "run_metadata.json"
+                    Path(directory)
+                    / "run_metadata.json"
             )
 
             saved_path = save_run_metadata_atomic(
@@ -181,8 +182,8 @@ class ControlledIlluminationMetadataTests(
             )
 
             with output_path.open(
-                "r",
-                encoding="utf-8",
+                    "r",
+                    encoding="utf-8",
             ) as metadata_file:
                 saved_metadata = json.load(
                     metadata_file
@@ -219,7 +220,7 @@ class ControlledIlluminationMetadataTests(
             )
 
     def test_invalid_trial_number_is_rejected(
-        self,
+            self,
     ) -> None:
         invalid_metadata = replace(
             self.metadata,
@@ -227,7 +228,7 @@ class ControlledIlluminationMetadataTests(
         )
 
         with self.assertRaises(
-            ControlledIlluminationMetadataError
+                ControlledIlluminationMetadataError
         ):
             validate_run_metadata(
                 invalid_metadata,
@@ -235,7 +236,7 @@ class ControlledIlluminationMetadataTests(
             )
 
     def test_invalid_incidence_angle_is_rejected(
-        self,
+            self,
     ) -> None:
         invalid_metadata = replace(
             self.metadata,
@@ -243,7 +244,7 @@ class ControlledIlluminationMetadataTests(
         )
 
         with self.assertRaises(
-            ControlledIlluminationMetadataError
+                ControlledIlluminationMetadataError
         ):
             validate_run_metadata(
                 invalid_metadata,
@@ -251,7 +252,7 @@ class ControlledIlluminationMetadataTests(
             )
 
     def test_constant_source_rejects_target_lux(
-        self,
+            self,
     ) -> None:
         invalid_metadata = replace(
             self.metadata,
@@ -260,7 +261,7 @@ class ControlledIlluminationMetadataTests(
         )
 
         with self.assertRaises(
-            ControlledIlluminationMetadataError
+                ControlledIlluminationMetadataError
         ):
             validate_run_metadata(
                 invalid_metadata,
@@ -268,7 +269,7 @@ class ControlledIlluminationMetadataTests(
             )
 
     def test_missing_camera_setting_is_rejected(
-        self,
+            self,
     ) -> None:
         camera_settings = dict(
             self.metadata.camera_settings
@@ -281,7 +282,7 @@ class ControlledIlluminationMetadataTests(
         )
 
         with self.assertRaises(
-            ControlledIlluminationMetadataError
+                ControlledIlluminationMetadataError
         ):
             validate_run_metadata(
                 invalid_metadata,
@@ -289,10 +290,10 @@ class ControlledIlluminationMetadataTests(
             )
 
     def test_negative_lux_is_rejected(
-        self,
+            self,
     ) -> None:
         with self.assertRaises(
-            ControlledIlluminationMetadataError
+                ControlledIlluminationMetadataError
         ):
             IlluminanceMeasurements(
                 centre_lux=-1.0,
@@ -309,7 +310,7 @@ class ControlledIlluminationMetadataTests(
             )
 
     def test_generated_identifiers_are_unique(
-        self,
+            self,
     ) -> None:
         first_identifier = (
             create_unique_identifier("run")
@@ -325,6 +326,54 @@ class ControlledIlluminationMetadataTests(
         self.assertTrue(
             first_identifier.startswith("run-")
         )
+
+    def test_invalid_collected_timestamp_is_rejected(
+        self,
+    ) -> None:
+        invalid_metadata = replace(
+            self.metadata,
+            collected_at_utc="invalid",
+        )
+
+        with self.assertRaises(
+            ControlledIlluminationMetadataError
+        ):
+            validate_run_metadata(
+                invalid_metadata,
+                self.config,
+            )
+
+    def test_non_string_git_sha_is_rejected(
+        self,
+    ) -> None:
+        invalid_metadata = replace(
+            self.metadata,
+            git_commit_sha=123,  # type: ignore[arg-type]
+        )
+
+        with self.assertRaises(
+            ControlledIlluminationMetadataError
+        ):
+            validate_run_metadata(
+                invalid_metadata,
+                self.config,
+            )
+
+    def test_non_numeric_incidence_angle_is_rejected(
+        self,
+    ) -> None:
+        invalid_metadata = replace(
+            self.metadata,
+            incidence_angle_degrees="invalid",  # type: ignore[arg-type]
+        )
+
+        with self.assertRaises(
+            ControlledIlluminationMetadataError
+        ):
+            validate_run_metadata(
+                invalid_metadata,
+                self.config,
+            )
 
 
 if __name__ == "__main__":

--- a/benchmarks/experiments/tests/test_validate_controlled_illumination_metadata.py
+++ b/benchmarks/experiments/tests/test_validate_controlled_illumination_metadata.py
@@ -1,0 +1,97 @@
+from contextlib import (
+    redirect_stderr,
+    redirect_stdout,
+)
+import io
+from pathlib import Path
+import tempfile
+import unittest
+
+from benchmarks.experiments.controlled_illumination_metadata import (
+    load_controlled_illumination_config,
+    save_run_metadata_atomic,
+)
+from benchmarks.experiments.generate_dry_run_metadata import (
+    build_dry_run_metadata,
+)
+from benchmarks.experiments.validate_controlled_illumination_metadata import (
+    main as validator_main,
+)
+
+
+class ControlledIlluminationValidatorTests(
+    unittest.TestCase
+):
+    def setUp(self) -> None:
+        self.config = (
+            load_controlled_illumination_config()
+        )
+        self.metadata = build_dry_run_metadata(
+            self.config,
+            git_commit_sha="c" * 40,
+        )
+
+    def test_valid_metadata_returns_success(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            metadata_path = (
+                Path(directory)
+                / "run_metadata.json"
+            )
+
+            save_run_metadata_atomic(
+                self.metadata,
+                config=self.config,
+                output_path=metadata_path,
+            )
+
+            standard_output = io.StringIO()
+
+            with redirect_stdout(standard_output):
+                exit_code = validator_main(
+                    [str(metadata_path)]
+                )
+
+            self.assertEqual(
+                exit_code,
+                0,
+            )
+            self.assertIn(
+                "metadata validation passed",
+                standard_output.getvalue(),
+            )
+
+    def test_invalid_metadata_returns_failure(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            metadata_path = (
+                Path(directory)
+                / "invalid_metadata.json"
+            )
+
+            metadata_path.write_text(
+                "{}\n",
+                encoding="utf-8",
+            )
+
+            standard_error = io.StringIO()
+
+            with redirect_stderr(standard_error):
+                exit_code = validator_main(
+                    [str(metadata_path)]
+                )
+
+            self.assertEqual(
+                exit_code,
+                1,
+            )
+            self.assertIn(
+                "Metadata validation failed",
+                standard_error.getvalue(),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/experiments/validate_controlled_illumination_metadata.py
+++ b/benchmarks/experiments/validate_controlled_illumination_metadata.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+from typing import Sequence
+
+from benchmarks.experiments.controlled_illumination_metadata import (
+    ControlledIlluminationConfigError,
+    ControlledIlluminationMetadataError,
+    load_controlled_illumination_config,
+    load_run_metadata,
+)
+
+
+def parse_arguments(
+    arguments: Sequence[str] | None = None,
+) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate one or more controlled-illumination "
+            "run metadata files."
+        )
+    )
+    parser.add_argument(
+        "metadata_paths",
+        nargs="+",
+        type=Path,
+        help="Run metadata JSON files to validate.",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help=(
+            "Optional controlled-illumination "
+            "configuration path."
+        ),
+    )
+
+    return parser.parse_args(arguments)
+
+
+def main(
+    arguments: Sequence[str] | None = None,
+) -> int:
+    parsed_arguments = parse_arguments(arguments)
+
+    try:
+        config = load_controlled_illumination_config(
+            parsed_arguments.config
+        )
+
+        for metadata_path in (
+            parsed_arguments.metadata_paths
+        ):
+            metadata = load_run_metadata(
+                metadata_path,
+                config=config,
+            )
+
+            print(
+                f"Valid metadata: {metadata_path}"
+            )
+            print(
+                f"  Experiment ID: "
+                f"{metadata.experiment_id}"
+            )
+            print(
+                f"  Run ID: {metadata.run_id}"
+            )
+            print(
+                f"  Phase: {metadata.phase}"
+            )
+            print(
+                f"  Platform: {metadata.platform}"
+            )
+            print(
+                f"  Architecture: "
+                f"{metadata.architecture}"
+            )
+            print(
+                f"  Dry run: {metadata.dry_run}"
+            )
+
+    except (
+        FileNotFoundError,
+        ControlledIlluminationConfigError,
+        ControlledIlluminationMetadataError,
+    ) as error:
+        print(
+            f"Metadata validation failed: {error}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        "Controlled-illumination metadata "
+        "validation passed."
+    )
+    print(
+        "Validated files: "
+        f"{len(parsed_arguments.metadata_paths)}"
+    )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This pull request adds the configuration, metadata, validation and dry-run infrastructure required for the VisionLab controlled-illumination experiments.

The implementation prepares the software workflow before physical lighting equipment, Raspberry Pi and NVIDIA Jetson hardware are available.

## Changes

* Added a shared controlled-illumination experiment configuration.
* Defined constant-lux and constant-source experiment phases.
* Added configurable illuminance levels and incidence angles.
* Added architecture, platform, algorithm, resolution and trial configuration.
* Added structured resolution, illuminance and run metadata models.
* Added five-position lux measurement and derived summary calculations.
* Added experiment and run identifier generation.
* Added configuration and run-metadata validation.
* Added validation for:

  * Experiment phases
  * Architectures and platforms
  * Algorithms and resolutions
  * Trial numbers
  * Illuminance levels and incidence angles
  * Camera settings
  * UTC timestamps
  * Git commit SHAs
  * Frame deadlines
  * Temperature measurements
  * Constant-lux and constant-source constraints
* Added atomic JSON metadata storage.
* Added validated JSON metadata loading.
* Added a hardware-independent dry-run metadata generator.
* Added a command-line metadata validator.
* Added experiment-infrastructure documentation.
* Linked the infrastructure guide from the main benchmark README.
* Added automated tests for valid and invalid metadata scenarios.

## Validation

The configuration validator passes:

```bash
python benchmarks/experiments/controlled_illumination_metadata.py
```

The controlled-illumination test suite passes:

```bash
python -m unittest discover \
-s benchmarks/experiments/tests \
-p "test_*.py" \
-v
```

Result:

```text
Ran 12 tests
OK
```

The dry-run generator completes successfully:

```bash
python -m benchmarks.experiments.generate_dry_run_metadata
```

Generated metadata passes the CLI validator:

```bash
python -m \
benchmarks.experiments.validate_controlled_illumination_metadata \
path/to/run_metadata.json
```

Additional checks completed:

* `git diff --check` passes.
* No merge-conflict markers are present.
* Generated dry-run results remain excluded from Git.
* No physical experiment results are included in this pull request.

## Scope

This pull request provides the metadata and validation foundation for controlled-illumination experiments.

It does not:

* Run the physical illumination experiment.
* Communicate automatically with a lux meter.
* Deploy the system to Raspberry Pi or NVIDIA Jetson.
* Add hardware-specific acceleration.
* Select the final production architecture.
* Draw scientific conclusions from physical experiment results.

## Documentation

The infrastructure workflow is documented in:

```text
benchmarks/experiments/README.md
```

The corresponding scientific protocol remains available in:

```text
benchmarks/experiments/controlled_illumination_protocol.md
```

Closes #28