### PR TITLE
feat: add resumable controlled-illumination run tracking

### DIFF
--- a/benchmarks/experiments/README.md
+++ b/benchmarks/experiments/README.md
@@ -24,6 +24,10 @@ The infrastructure in this directory does not perform the physical experiment au
 | `generate_controlled_illumination_run_plan.py` | Provides dry-run validation and JSON/CSV manifest generation through the CLI. |
 | `tests/test_controlled_illumination_run_planner.py` | Tests matrix expansion, duplicate rejection, deterministic ordering and atomic manifests. |
 | `tests/test_generate_controlled_illumination_run_plan.py` | Tests run-planner CLI dry-run and manifest-generation behavior. |
+| `controlled_illumination_run_state.py`                    | Defines run states, validated transitions, progress persistence and resume integrity.                            |
+| `manage_controlled_illumination_run.py`                   | Provides CLI commands for initializing, resuming and updating experiment execution progress.                    |
+| `tests/test_controlled_illumination_run_state.py`         | Tests state transitions, progress integrity, persistence and timestamp chronology.                              |
+| `tests/test_manage_controlled_illumination_run.py`        | Tests the controlled-illumination run-management CLI.                                                            |
 
 ## Experiment phases
 
@@ -385,3 +389,118 @@ benchmarks.experiments.generate_controlled_illumination_run_plan \
 
 Generated run plans are experimental outputs and must not be committed
 to the repository.
+
+## Resumable run execution tracking
+
+The run-tracking CLI records the execution state of every run in a controlled-illumination manifest. It supports interruption recovery without losing completed, failed or skipped run information.
+
+By default, progress is stored beside the selected run plan:
+
+```text
+<run-plan-directory>/run_progress.json
+```
+
+The progress file is written atomically and bound to the run-plan manifest by its SHA-256 hash. A progress file cannot be resumed with a modified or different run plan.
+
+### Run states
+
+Each run uses one of the following states:
+
+* `planned`
+* `running`
+* `completed`
+* `failed`
+* `skipped`
+
+Only one run may be in the `running` state at a time. Invalid state transitions and inconsistent timestamps are rejected.
+
+### Initialize or resume progress
+
+From the repository root:
+
+```bash
+python -m \
+benchmarks.experiments.manage_controlled_illumination_run \
+--plan path/to/run_plan.json \
+init
+```
+
+If a compatible progress file already exists, it is loaded instead of overwritten.
+
+### Display experiment status
+
+```bash
+python -m \
+benchmarks.experiments.manage_controlled_illumination_run \
+--plan path/to/run_plan.json \
+status
+```
+
+### Start the next planned run
+
+```bash
+python -m \
+benchmarks.experiments.manage_controlled_illumination_run \
+--plan path/to/run_plan.json \
+start-next
+```
+
+The command selects the next run according to `execution_order`.
+
+### Complete a running run
+
+```bash
+python -m \
+benchmarks.experiments.manage_controlled_illumination_run \
+--plan path/to/run_plan.json \
+complete \
+--run-id RUN_ID
+```
+
+### Mark a running run as failed
+
+```bash
+python -m \
+benchmarks.experiments.manage_controlled_illumination_run \
+--plan path/to/run_plan.json \
+fail \
+--run-id RUN_ID \
+--reason "Failure reason"
+```
+
+### Skip a planned run
+
+```bash
+python -m \
+benchmarks.experiments.manage_controlled_illumination_run \
+--plan path/to/run_plan.json \
+skip \
+--run-id RUN_ID \
+--reason "Skip reason"
+```
+
+### Return a failed or skipped run to planned status
+
+```bash
+python -m \
+benchmarks.experiments.manage_controlled_illumination_run \
+--plan path/to/run_plan.json \
+replan \
+--run-id RUN_ID
+```
+
+Replanning preserves the previous attempt count. Starting the run again increments the attempt count.
+
+### Custom progress path
+
+Use `--progress` before the subcommand when the progress file must be stored elsewhere:
+
+```bash
+python -m \
+benchmarks.experiments.manage_controlled_illumination_run \
+--plan path/to/run_plan.json \
+--progress path/to/run_progress.json \
+status
+```
+
+Generated `run_progress.json` files are experiment artifacts and must not be committed to Git.

--- a/benchmarks/experiments/controlled_illumination_run_planner.py
+++ b/benchmarks/experiments/controlled_illumination_run_planner.py
@@ -941,3 +941,217 @@ def write_run_plan_manifests_atomic(
         )
 
     return json_path, csv_path
+
+def require_plan_mapping(
+    value: Any,
+    field_name: str,
+) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ControlledIlluminationRunPlanError(
+            f"{field_name} must be an object."
+        )
+
+    return value
+
+
+def require_exact_plan_fields(
+    value: dict[str, Any],
+    required_fields: set[str],
+    field_name: str,
+) -> None:
+    actual_fields = set(value)
+
+    missing_fields = required_fields - actual_fields
+    unexpected_fields = actual_fields - required_fields
+
+    if missing_fields:
+        raise ControlledIlluminationRunPlanError(
+            f"Missing {field_name} fields: "
+            f"{sorted(missing_fields)}"
+        )
+
+    if unexpected_fields:
+        raise ControlledIlluminationRunPlanError(
+            f"Unexpected {field_name} fields: "
+            f"{sorted(unexpected_fields)}"
+        )
+
+
+def planned_run_from_dict(
+    value: Any,
+) -> PlannedRun:
+    run_data = require_plan_mapping(
+        value,
+        "planned run",
+    )
+
+    required_fields = {
+        "execution_order",
+        "experiment_id",
+        "run_id",
+        "phase",
+        "platform",
+        "architecture",
+        "algorithm",
+        "resolution",
+        "trial_number",
+        "incidence_angle_degrees",
+        "target_illuminance_lux",
+        "source_output_setting",
+        "target_fps",
+        "frame_deadline_ms",
+        "status",
+    }
+
+    require_exact_plan_fields(
+        run_data,
+        required_fields,
+        "planned run",
+    )
+
+    resolution_data = require_plan_mapping(
+        run_data["resolution"],
+        "planned run resolution",
+    )
+
+    require_exact_plan_fields(
+        resolution_data,
+        {
+            "width",
+            "height",
+        },
+        "planned run resolution",
+    )
+
+    resolution = ResolutionMetadata(
+        width=resolution_data["width"],
+        height=resolution_data["height"],
+    )
+
+    return PlannedRun(
+        execution_order=run_data[
+            "execution_order"
+        ],
+        experiment_id=run_data[
+            "experiment_id"
+        ],
+        run_id=run_data["run_id"],
+        phase=run_data["phase"],
+        platform=run_data["platform"],
+        architecture=run_data["architecture"],
+        algorithm=run_data["algorithm"],
+        resolution=resolution,
+        trial_number=run_data["trial_number"],
+        incidence_angle_degrees=run_data[
+            "incidence_angle_degrees"
+        ],
+        target_illuminance_lux=run_data[
+            "target_illuminance_lux"
+        ],
+        source_output_setting=run_data[
+            "source_output_setting"
+        ],
+        target_fps=run_data["target_fps"],
+        frame_deadline_ms=run_data[
+            "frame_deadline_ms"
+        ],
+        status=run_data["status"],
+    )
+
+
+def run_plan_from_dict(
+    value: Any,
+) -> ControlledIlluminationRunPlan:
+    plan_data = require_plan_mapping(
+        value,
+        "run plan",
+    )
+
+    required_fields = {
+        "schema_version",
+        "generated_at_utc",
+        "experiment_id",
+        "randomized",
+        "randomization_seed",
+        "run_count",
+        "runs",
+    }
+
+    require_exact_plan_fields(
+        plan_data,
+        required_fields,
+        "run plan",
+    )
+
+    runs_data = plan_data["runs"]
+
+    if not isinstance(runs_data, list) or not runs_data:
+        raise ControlledIlluminationRunPlanError(
+            "run plan runs must be a non-empty list."
+        )
+
+    plan = ControlledIlluminationRunPlan(
+        schema_version=plan_data[
+            "schema_version"
+        ],
+        generated_at_utc=plan_data[
+            "generated_at_utc"
+        ],
+        experiment_id=plan_data[
+            "experiment_id"
+        ],
+        randomized=plan_data["randomized"],
+        randomization_seed=plan_data[
+            "randomization_seed"
+        ],
+        runs=tuple(
+            planned_run_from_dict(run_data)
+            for run_data in runs_data
+        ),
+    )
+
+    stored_run_count = plan_data["run_count"]
+
+    if (
+        isinstance(stored_run_count, bool)
+        or not isinstance(stored_run_count, int)
+        or stored_run_count != plan.run_count
+    ):
+        raise ControlledIlluminationRunPlanError(
+            "Stored run_count does not match runs."
+        )
+
+    return plan
+
+
+def load_run_plan_manifest(
+    input_path: str | Path,
+) -> ControlledIlluminationRunPlan:
+    manifest_path = Path(input_path)
+
+    if not manifest_path.is_file():
+        raise ControlledIlluminationRunPlanError(
+            "Run-plan manifest was not found: "
+            f"{manifest_path}"
+        )
+
+    try:
+        with manifest_path.open(
+            "r",
+            encoding="utf-8",
+        ) as manifest_file:
+            manifest_data = json.load(
+                manifest_file
+            )
+    except (
+        OSError,
+        json.JSONDecodeError,
+    ) as error:
+        raise ControlledIlluminationRunPlanError(
+            "Run-plan manifest could not be loaded: "
+            f"{manifest_path}: {error}"
+        ) from error
+
+    return run_plan_from_dict(
+        manifest_data
+    )

--- a/benchmarks/experiments/controlled_illumination_run_state.py
+++ b/benchmarks/experiments/controlled_illumination_run_state.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from typing import Any

--- a/benchmarks/experiments/controlled_illumination_run_state.py
+++ b/benchmarks/experiments/controlled_illumination_run_state.py
@@ -6,6 +6,9 @@ from typing import Any
 from dataclasses import dataclass, replace
 import hashlib
 import json
+import os
+from pathlib import Path
+from uuid import uuid4
 
 from benchmarks.experiments.controlled_illumination_metadata import (
     validate_utc_timestamp,
@@ -704,3 +707,322 @@ def transition_progress_run(
         updated_at_utc=transitioned_at_utc,
         runs=updated_runs,
     )
+
+def require_state_mapping(
+    value: Any,
+    field_name: str,
+) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ControlledIlluminationRunStateError(
+            f"{field_name} must be an object."
+        )
+
+    return value
+
+
+def require_exact_state_fields(
+    value: dict[str, Any],
+    required_fields: set[str],
+    field_name: str,
+) -> None:
+    actual_fields = set(value)
+
+    missing_fields = required_fields - actual_fields
+    unexpected_fields = actual_fields - required_fields
+
+    if missing_fields:
+        raise ControlledIlluminationRunStateError(
+            f"Missing {field_name} fields: "
+            f"{sorted(missing_fields)}"
+        )
+
+    if unexpected_fields:
+        raise ControlledIlluminationRunStateError(
+            f"Unexpected {field_name} fields: "
+            f"{sorted(unexpected_fields)}"
+        )
+
+
+def run_state_from_dict(
+    value: Any,
+) -> RunState:
+    state_data = require_state_mapping(
+        value,
+        "run state",
+    )
+
+    required_fields = {
+        "run_id",
+        "execution_order",
+        "status",
+        "attempt_count",
+        "started_at_utc",
+        "finished_at_utc",
+        "failure_reason",
+        "skip_reason",
+    }
+
+    require_exact_state_fields(
+        state_data,
+        required_fields,
+        "run state",
+    )
+
+    return RunState(
+        run_id=state_data["run_id"],
+        execution_order=(
+            state_data["execution_order"]
+        ),
+        status=state_data["status"],
+        attempt_count=state_data["attempt_count"],
+        started_at_utc=(
+            state_data["started_at_utc"]
+        ),
+        finished_at_utc=(
+            state_data["finished_at_utc"]
+        ),
+        failure_reason=(
+            state_data["failure_reason"]
+        ),
+        skip_reason=state_data["skip_reason"],
+    )
+
+
+def progress_from_dict(
+    value: Any,
+) -> ControlledIlluminationProgress:
+    progress_data = require_state_mapping(
+        value,
+        "progress",
+    )
+
+    required_fields = {
+        "schema_version",
+        "experiment_id",
+        "run_plan_sha256",
+        "created_at_utc",
+        "updated_at_utc",
+        "run_count",
+        "status_counts",
+        "runs",
+    }
+
+    require_exact_state_fields(
+        progress_data,
+        required_fields,
+        "progress",
+    )
+
+    runs_data = progress_data["runs"]
+
+    if not isinstance(runs_data, list) or not runs_data:
+        raise ControlledIlluminationRunStateError(
+            "progress.runs must be a non-empty list."
+        )
+
+    progress = ControlledIlluminationProgress(
+        schema_version=progress_data[
+            "schema_version"
+        ],
+        experiment_id=progress_data[
+            "experiment_id"
+        ],
+        run_plan_sha256=progress_data[
+            "run_plan_sha256"
+        ],
+        created_at_utc=progress_data[
+            "created_at_utc"
+        ],
+        updated_at_utc=progress_data[
+            "updated_at_utc"
+        ],
+        runs=tuple(
+            run_state_from_dict(run_data)
+            for run_data in runs_data
+        ),
+    )
+
+    stored_run_count = progress_data["run_count"]
+
+    if (
+        isinstance(stored_run_count, bool)
+        or not isinstance(stored_run_count, int)
+        or stored_run_count != progress.run_count
+    ):
+        raise ControlledIlluminationRunStateError(
+            "Stored run_count does not match runs."
+        )
+
+    stored_status_counts = progress_data[
+        "status_counts"
+    ]
+
+    if not isinstance(stored_status_counts, dict):
+        raise ControlledIlluminationRunStateError(
+            "status_counts must be an object."
+        )
+
+    if stored_status_counts != progress.status_counts:
+        raise ControlledIlluminationRunStateError(
+            "Stored status_counts do not match runs."
+        )
+
+    return progress
+
+
+def validate_progress_matches_plan(
+    progress: ControlledIlluminationProgress,
+    plan: ControlledIlluminationRunPlan,
+) -> None:
+    if not isinstance(
+        progress,
+        ControlledIlluminationProgress,
+    ):
+        raise ControlledIlluminationRunStateError(
+            "progress must be "
+            "ControlledIlluminationProgress."
+        )
+
+    if not isinstance(
+        plan,
+        ControlledIlluminationRunPlan,
+    ):
+        raise ControlledIlluminationRunStateError(
+            "plan must be ControlledIlluminationRunPlan."
+        )
+
+    if progress.experiment_id != plan.experiment_id:
+        raise ControlledIlluminationRunStateError(
+            "Progress experiment_id does not "
+            "match the run plan."
+        )
+
+    expected_hash = calculate_run_plan_sha256(
+        plan
+    )
+
+    if progress.run_plan_sha256 != expected_hash:
+        raise ControlledIlluminationRunStateError(
+            "Progress was created from a different "
+            "run plan."
+        )
+
+
+def save_run_progress_atomic(
+    progress: ControlledIlluminationProgress,
+    output_path: str | Path,
+) -> Path:
+    if not isinstance(
+        progress,
+        ControlledIlluminationProgress,
+    ):
+        raise ControlledIlluminationRunStateError(
+            "progress must be "
+            "ControlledIlluminationProgress."
+        )
+
+    progress_path = Path(output_path)
+    progress_path.parent.mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    temporary_path = progress_path.with_name(
+        f".{progress_path.name}."
+        f"{uuid4().hex}.tmp"
+    )
+
+    try:
+        with temporary_path.open(
+            "w",
+            encoding="utf-8",
+        ) as progress_file:
+            json.dump(
+                progress.to_dict(),
+                progress_file,
+                indent=2,
+                ensure_ascii=False,
+            )
+            progress_file.write("\n")
+            progress_file.flush()
+            os.fsync(progress_file.fileno())
+
+        os.replace(
+            temporary_path,
+            progress_path,
+        )
+    finally:
+        temporary_path.unlink(
+            missing_ok=True,
+        )
+
+    return progress_path
+
+
+def load_run_progress(
+    progress_path: str | Path,
+    *,
+    plan: ControlledIlluminationRunPlan | None = None,
+) -> ControlledIlluminationProgress:
+    input_path = Path(progress_path)
+
+    if not input_path.is_file():
+        raise ControlledIlluminationRunStateError(
+            f"Progress file was not found: {input_path}"
+        )
+
+    try:
+        with input_path.open(
+            "r",
+            encoding="utf-8",
+        ) as progress_file:
+            progress_data = json.load(
+                progress_file
+            )
+    except (
+        OSError,
+        json.JSONDecodeError,
+    ) as error:
+        raise ControlledIlluminationRunStateError(
+            f"Progress file could not be loaded: "
+            f"{input_path}: {error}"
+        ) from error
+
+    progress = progress_from_dict(
+        progress_data
+    )
+
+    if plan is not None:
+        validate_progress_matches_plan(
+            progress,
+            plan,
+        )
+
+    return progress
+
+
+def load_or_initialize_run_progress(
+    plan: ControlledIlluminationRunPlan,
+    progress_path: str | Path,
+    *,
+    created_at_utc: str,
+) -> ControlledIlluminationProgress:
+    output_path = Path(progress_path)
+
+    if output_path.exists():
+        return load_run_progress(
+            output_path,
+            plan=plan,
+        )
+
+    progress = initialize_run_progress(
+        plan,
+        created_at_utc=created_at_utc,
+    )
+
+    save_run_progress_atomic(
+        progress,
+        output_path,
+    )
+
+    return progress

--- a/benchmarks/experiments/controlled_illumination_run_state.py
+++ b/benchmarks/experiments/controlled_illumination_run_state.py
@@ -361,6 +361,16 @@ def transition_run_state(
         )
     )
 
+    if parse_validated_state_timestamp(
+            transition_timestamp
+    ) < parse_validated_state_timestamp(
+        progress.updated_at_utc
+    ):
+        raise ControlledIlluminationRunStateError(
+            "transitioned_at_utc must not be earlier "
+            "than progress.updated_at_utc."
+        )
+
     allowed_targets = ALLOWED_STATUS_TRANSITIONS[
         state.status
     ]

--- a/benchmarks/experiments/controlled_illumination_run_state.py
+++ b/benchmarks/experiments/controlled_illumination_run_state.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 from enum import Enum
 from typing import Any
 from dataclasses import dataclass, replace
@@ -147,6 +148,18 @@ def validate_optional_timestamp(
             str(error)
         ) from error
 
+def parse_validated_state_timestamp(
+    value: str,
+) -> datetime:
+    normalized_value = (
+        f"{value[:-1]}+00:00"
+        if value.endswith("Z")
+        else value
+    )
+
+    return datetime.fromisoformat(
+        normalized_value
+    )
 
 def validate_optional_reason(
     value: Any,
@@ -204,6 +217,22 @@ class RunState:
             self.finished_at_utc,
             "finished_at_utc",
         )
+
+        if (
+                self.started_at_utc is not None
+                and self.finished_at_utc is not None
+                and parse_validated_state_timestamp(
+            self.finished_at_utc
+        )
+                < parse_validated_state_timestamp(
+            self.started_at_utc
+        )
+        ):
+            raise ControlledIlluminationRunStateError(
+                "finished_at_utc must not be earlier "
+                "than started_at_utc."
+            )
+
         validate_optional_reason(
             self.failure_reason,
             "failure_reason",
@@ -493,6 +522,16 @@ class ControlledIlluminationProgress:
             self.updated_at_utc,
             "updated_at_utc",
         )
+
+        if parse_validated_state_timestamp(
+                self.updated_at_utc
+        ) < parse_validated_state_timestamp(
+            self.created_at_utc
+        ):
+            raise ControlledIlluminationRunStateError(
+                "updated_at_utc must not be earlier "
+                "than created_at_utc."
+            )
 
         if not isinstance(self.runs, tuple) or not self.runs:
             raise ControlledIlluminationRunStateError(

--- a/benchmarks/experiments/controlled_illumination_run_state.py
+++ b/benchmarks/experiments/controlled_illumination_run_state.py
@@ -1,0 +1,402 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+from dataclasses import dataclass, replace
+
+from benchmarks.experiments.controlled_illumination_metadata import (
+    validate_utc_timestamp,
+)
+
+
+RUN_PROGRESS_SCHEMA_VERSION = 1
+RUN_PROGRESS_FILE_NAME = "run_progress.json"
+
+
+class RunStatus(str, Enum):
+    PLANNED = "planned"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+
+
+ALLOWED_STATUS_TRANSITIONS = {
+    RunStatus.PLANNED: frozenset(
+        {
+            RunStatus.RUNNING,
+            RunStatus.SKIPPED,
+        }
+    ),
+    RunStatus.RUNNING: frozenset(
+        {
+            RunStatus.COMPLETED,
+            RunStatus.FAILED,
+        }
+    ),
+    RunStatus.COMPLETED: frozenset(),
+    RunStatus.FAILED: frozenset(
+        {
+            RunStatus.PLANNED,
+        }
+    ),
+    RunStatus.SKIPPED: frozenset(
+        {
+            RunStatus.PLANNED,
+        }
+    ),
+}
+
+
+class ControlledIlluminationRunStateError(
+    ValueError
+):
+    """Raised when experiment run state is invalid."""
+
+
+def require_non_empty_state_string(
+    value: Any,
+    field_name: str,
+) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ControlledIlluminationRunStateError(
+            f"{field_name} must be a non-empty string."
+        )
+
+    return value
+
+
+def require_positive_state_integer(
+    value: Any,
+    field_name: str,
+) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value <= 0
+    ):
+        raise ControlledIlluminationRunStateError(
+            f"{field_name} must be a positive integer."
+        )
+
+    return value
+
+
+def require_non_negative_state_integer(
+    value: Any,
+    field_name: str,
+) -> int:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value < 0
+    ):
+        raise ControlledIlluminationRunStateError(
+            f"{field_name} must be a "
+            "non-negative integer."
+        )
+
+    return value
+
+
+def normalize_run_status(
+    value: Any,
+) -> RunStatus:
+    if isinstance(value, RunStatus):
+        return value
+
+    if not isinstance(value, str):
+        raise ControlledIlluminationRunStateError(
+            "status must be a supported string."
+        )
+
+    try:
+        return RunStatus(value)
+    except ValueError as error:
+        raise ControlledIlluminationRunStateError(
+            f"Unsupported run status: {value}"
+        ) from error
+
+
+def validate_optional_timestamp(
+    value: Any,
+    field_name: str,
+) -> None:
+    if value is None:
+        return
+
+    try:
+        validate_utc_timestamp(
+            value,
+            field_name,
+        )
+    except ValueError as error:
+        raise ControlledIlluminationRunStateError(
+            str(error)
+        ) from error
+
+
+def validate_optional_reason(
+    value: Any,
+    field_name: str,
+) -> None:
+    if value is None:
+        return
+
+    require_non_empty_state_string(
+        value,
+        field_name,
+    )
+
+
+@dataclass(frozen=True)
+class RunState:
+    run_id: str
+    execution_order: int
+    status: RunStatus = RunStatus.PLANNED
+    attempt_count: int = 0
+    started_at_utc: str | None = None
+    finished_at_utc: str | None = None
+    failure_reason: str | None = None
+    skip_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        require_non_empty_state_string(
+            self.run_id,
+            "run_id",
+        )
+        require_positive_state_integer(
+            self.execution_order,
+            "execution_order",
+        )
+        require_non_negative_state_integer(
+            self.attempt_count,
+            "attempt_count",
+        )
+
+        normalized_status = normalize_run_status(
+            self.status
+        )
+
+        object.__setattr__(
+            self,
+            "status",
+            normalized_status,
+        )
+
+        validate_optional_timestamp(
+            self.started_at_utc,
+            "started_at_utc",
+        )
+        validate_optional_timestamp(
+            self.finished_at_utc,
+            "finished_at_utc",
+        )
+        validate_optional_reason(
+            self.failure_reason,
+            "failure_reason",
+        )
+        validate_optional_reason(
+            self.skip_reason,
+            "skip_reason",
+        )
+
+        self.validate_status_fields()
+
+    def validate_status_fields(self) -> None:
+        if self.status == RunStatus.PLANNED:
+            if any(
+                value is not None
+                for value in (
+                    self.started_at_utc,
+                    self.finished_at_utc,
+                    self.failure_reason,
+                    self.skip_reason,
+                )
+            ):
+                raise ControlledIlluminationRunStateError(
+                    "A planned run must not contain "
+                    "execution timestamps or reasons."
+                )
+
+        if self.status == RunStatus.RUNNING:
+            if self.started_at_utc is None:
+                raise ControlledIlluminationRunStateError(
+                    "A running run requires started_at_utc."
+                )
+
+            if (
+                self.attempt_count <= 0
+                or self.finished_at_utc is not None
+                or self.failure_reason is not None
+                or self.skip_reason is not None
+            ):
+                raise ControlledIlluminationRunStateError(
+                    "Running run fields are inconsistent."
+                )
+
+        if self.status == RunStatus.COMPLETED:
+            if (
+                self.attempt_count <= 0
+                or self.started_at_utc is None
+                or self.finished_at_utc is None
+                or self.failure_reason is not None
+                or self.skip_reason is not None
+            ):
+                raise ControlledIlluminationRunStateError(
+                    "Completed run fields are inconsistent."
+                )
+
+        if self.status == RunStatus.FAILED:
+            if (
+                self.attempt_count <= 0
+                or self.started_at_utc is None
+                or self.finished_at_utc is None
+                or self.failure_reason is None
+                or self.skip_reason is not None
+            ):
+                raise ControlledIlluminationRunStateError(
+                    "Failed run fields are inconsistent."
+                )
+
+        if self.status == RunStatus.SKIPPED:
+            if (
+                self.started_at_utc is not None
+                or self.finished_at_utc is None
+                or self.failure_reason is not None
+                or self.skip_reason is None
+            ):
+                raise ControlledIlluminationRunStateError(
+                    "Skipped run fields are inconsistent."
+                )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "execution_order": self.execution_order,
+            "status": self.status.value,
+            "attempt_count": self.attempt_count,
+            "started_at_utc": self.started_at_utc,
+            "finished_at_utc": self.finished_at_utc,
+            "failure_reason": self.failure_reason,
+            "skip_reason": self.skip_reason,
+        }
+
+    def validate_required_state_timestamp(
+            value: Any,
+            field_name: str,
+    ) -> str:
+        timestamp = require_non_empty_state_string(
+            value,
+            field_name,
+        )
+
+        validate_optional_timestamp(
+            timestamp,
+            field_name,
+        )
+
+        return timestamp
+
+def transition_run_state(
+        state: RunState,
+        target_status: RunStatus | str,
+        transitioned_at_utc: str,
+        *,
+        reason: str | None = None,
+) -> RunState:
+    if not isinstance(state, RunState):
+        raise ControlledIlluminationRunStateError(
+            "state must be RunState."
+        )
+
+    normalized_target_status = normalize_run_status(
+        target_status
+    )
+    transition_timestamp = (
+        validate_required_state_timestamp(
+            transitioned_at_utc,
+            "transitioned_at_utc",
+        )
+    )
+
+    allowed_targets = ALLOWED_STATUS_TRANSITIONS[
+        state.status
+    ]
+
+    if normalized_target_status not in allowed_targets:
+        raise ControlledIlluminationRunStateError(
+            "Invalid run-state transition: "
+            f"{state.status.value} -> "
+            f"{normalized_target_status.value}"
+        )
+
+    reason_required = normalized_target_status in {
+        RunStatus.FAILED,
+        RunStatus.SKIPPED,
+    }
+
+    if reason_required:
+        require_non_empty_state_string(
+            reason,
+            "reason",
+        )
+    elif reason is not None:
+        raise ControlledIlluminationRunStateError(
+            "A reason is only allowed for failed "
+            "or skipped transitions."
+        )
+
+    if normalized_target_status == RunStatus.RUNNING:
+        return replace(
+            state,
+            status=RunStatus.RUNNING,
+            attempt_count=state.attempt_count + 1,
+            started_at_utc=transition_timestamp,
+            finished_at_utc=None,
+            failure_reason=None,
+            skip_reason=None,
+        )
+
+    if normalized_target_status == RunStatus.COMPLETED:
+        return replace(
+            state,
+            status=RunStatus.COMPLETED,
+            finished_at_utc=transition_timestamp,
+            failure_reason=None,
+            skip_reason=None,
+        )
+
+    if normalized_target_status == RunStatus.FAILED:
+        return replace(
+            state,
+            status=RunStatus.FAILED,
+            finished_at_utc=transition_timestamp,
+            failure_reason=reason,
+            skip_reason=None,
+        )
+
+    if normalized_target_status == RunStatus.SKIPPED:
+        return replace(
+            state,
+            status=RunStatus.SKIPPED,
+            started_at_utc=None,
+            finished_at_utc=transition_timestamp,
+            failure_reason=None,
+            skip_reason=reason,
+        )
+
+    if normalized_target_status == RunStatus.PLANNED:
+        return replace(
+            state,
+            status=RunStatus.PLANNED,
+            started_at_utc=None,
+            finished_at_utc=None,
+            failure_reason=None,
+            skip_reason=None,
+        )
+
+    raise ControlledIlluminationRunStateError(
+        "Unsupported run-state transition."
+    )

--- a/benchmarks/experiments/controlled_illumination_run_state.py
+++ b/benchmarks/experiments/controlled_illumination_run_state.py
@@ -361,16 +361,6 @@ def transition_run_state(
         )
     )
 
-    if parse_validated_state_timestamp(
-            transition_timestamp
-    ) < parse_validated_state_timestamp(
-        progress.updated_at_utc
-    ):
-        raise ControlledIlluminationRunStateError(
-            "transitioned_at_utc must not be earlier "
-            "than progress.updated_at_utc."
-        )
-
     allowed_targets = ALLOWED_STATUS_TRANSITIONS[
         state.status
     ]
@@ -694,7 +684,6 @@ def initialize_run_progress(
         runs=run_states,
     )
 
-
 def transition_progress_run(
     progress: ControlledIlluminationProgress,
     run_id: str,
@@ -715,18 +704,38 @@ def transition_progress_run(
     current_state = progress.get_run_state(
         run_id
     )
+
     normalized_target_status = normalize_run_status(
         target_status
     )
+
+    transition_timestamp = (
+        validate_required_state_timestamp(
+            transitioned_at_utc,
+            "transitioned_at_utc",
+        )
+    )
+
+    if parse_validated_state_timestamp(
+        transition_timestamp
+    ) < parse_validated_state_timestamp(
+        progress.updated_at_utc
+    ):
+        raise ControlledIlluminationRunStateError(
+            "transitioned_at_utc must not be earlier "
+            "than progress.updated_at_utc."
+        )
 
     if normalized_target_status == RunStatus.RUNNING:
         running_state = next(
             (
                 run_state
                 for run_state in progress.runs
-                if run_state.status
-                == RunStatus.RUNNING
-                and run_state.run_id != run_id
+                if (
+                    run_state.status
+                    == RunStatus.RUNNING
+                    and run_state.run_id != run_id
+                )
             ),
             None,
         )
@@ -740,7 +749,7 @@ def transition_progress_run(
     updated_state = transition_run_state(
         current_state,
         normalized_target_status,
-        transitioned_at_utc,
+        transition_timestamp,
         reason=reason,
     )
 
@@ -753,7 +762,7 @@ def transition_progress_run(
 
     return replace(
         progress,
-        updated_at_utc=transitioned_at_utc,
+        updated_at_utc=transition_timestamp,
         runs=updated_runs,
     )
 

--- a/benchmarks/experiments/controlled_illumination_run_state.py
+++ b/benchmarks/experiments/controlled_illumination_run_state.py
@@ -4,9 +4,17 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 from dataclasses import dataclass, replace
+import hashlib
+import json
 
 from benchmarks.experiments.controlled_illumination_metadata import (
     validate_utc_timestamp,
+    ResolutionMetadata,
+)
+
+from benchmarks.experiments.controlled_illumination_run_planner import (
+    ControlledIlluminationRunPlan,
+    PlannedRun,
 )
 
 
@@ -283,21 +291,21 @@ class RunState:
             "skip_reason": self.skip_reason,
         }
 
-    def validate_required_state_timestamp(
-            value: Any,
-            field_name: str,
-    ) -> str:
-        timestamp = require_non_empty_state_string(
-            value,
-            field_name,
-        )
+def validate_required_state_timestamp(
+        value: Any,
+        field_name: str,
+) -> str:
+    timestamp = require_non_empty_state_string(
+        value,
+        field_name,
+    )
 
-        validate_optional_timestamp(
-            timestamp,
-            field_name,
-        )
+    validate_optional_timestamp(
+        timestamp,
+        field_name,
+    )
 
-        return timestamp
+    return timestamp
 
 def transition_run_state(
         state: RunState,
@@ -399,4 +407,300 @@ def transition_run_state(
 
     raise ControlledIlluminationRunStateError(
         "Unsupported run-state transition."
+    )
+
+def calculate_run_plan_sha256(
+    plan: ControlledIlluminationRunPlan,
+) -> str:
+    if not isinstance(
+        plan,
+        ControlledIlluminationRunPlan,
+    ):
+        raise ControlledIlluminationRunStateError(
+            "plan must be ControlledIlluminationRunPlan."
+        )
+
+    canonical_plan = json.dumps(
+        plan.to_dict(),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+    return hashlib.sha256(
+        canonical_plan
+    ).hexdigest()
+
+
+def validate_run_plan_sha256(
+    value: Any,
+) -> str:
+    hash_value = require_non_empty_state_string(
+        value,
+        "run_plan_sha256",
+    )
+
+    if (
+        len(hash_value) != 64
+        or any(
+            character not in "0123456789abcdef"
+            for character in hash_value
+        )
+    ):
+        raise ControlledIlluminationRunStateError(
+            "run_plan_sha256 must be a lowercase "
+            "SHA-256 value."
+        )
+
+    return hash_value
+
+
+@dataclass(frozen=True)
+class ControlledIlluminationProgress:
+    schema_version: int
+    experiment_id: str
+    run_plan_sha256: str
+    created_at_utc: str
+    updated_at_utc: str
+    runs: tuple[RunState, ...]
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.schema_version, bool)
+            or not isinstance(self.schema_version, int)
+            or self.schema_version
+            != RUN_PROGRESS_SCHEMA_VERSION
+        ):
+            raise ControlledIlluminationRunStateError(
+                "schema_version must be 1."
+            )
+
+        require_non_empty_state_string(
+            self.experiment_id,
+            "experiment_id",
+        )
+        validate_run_plan_sha256(
+            self.run_plan_sha256
+        )
+        validate_required_state_timestamp(
+            self.created_at_utc,
+            "created_at_utc",
+        )
+        validate_required_state_timestamp(
+            self.updated_at_utc,
+            "updated_at_utc",
+        )
+
+        if not isinstance(self.runs, tuple) or not self.runs:
+            raise ControlledIlluminationRunStateError(
+                "runs must be a non-empty tuple."
+            )
+
+        if not all(
+            isinstance(run_state, RunState)
+            for run_state in self.runs
+        ):
+            raise ControlledIlluminationRunStateError(
+                "Every runs item must be RunState."
+            )
+
+        expected_orders = list(
+            range(1, len(self.runs) + 1)
+        )
+        actual_orders = [
+            run_state.execution_order
+            for run_state in self.runs
+        ]
+
+        if actual_orders != expected_orders:
+            raise ControlledIlluminationRunStateError(
+                "execution_order values must be "
+                "sequential and start at 1."
+            )
+
+        run_ids = [
+            run_state.run_id
+            for run_state in self.runs
+        ]
+
+        if len(run_ids) != len(set(run_ids)):
+            raise ControlledIlluminationRunStateError(
+                "Run IDs must be unique."
+            )
+
+        running_count = sum(
+            run_state.status == RunStatus.RUNNING
+            for run_state in self.runs
+        )
+
+        if running_count > 1:
+            raise ControlledIlluminationRunStateError(
+                "Only one run may be running."
+            )
+
+    @property
+    def run_count(self) -> int:
+        return len(self.runs)
+
+    @property
+    def status_counts(self) -> dict[str, int]:
+        return {
+            status.value: sum(
+                run_state.status == status
+                for run_state in self.runs
+            )
+            for status in RunStatus
+        }
+
+    @property
+    def next_planned_run(
+        self,
+    ) -> RunState | None:
+        return next(
+            (
+                run_state
+                for run_state in self.runs
+                if run_state.status
+                == RunStatus.PLANNED
+            ),
+            None,
+        )
+
+    def get_run_state(
+        self,
+        run_id: str,
+    ) -> RunState:
+        require_non_empty_state_string(
+            run_id,
+            "run_id",
+        )
+
+        for run_state in self.runs:
+            if run_state.run_id == run_id:
+                return run_state
+
+        raise ControlledIlluminationRunStateError(
+            f"Unknown run ID: {run_id}"
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "experiment_id": self.experiment_id,
+            "run_plan_sha256": (
+                self.run_plan_sha256
+            ),
+            "created_at_utc": self.created_at_utc,
+            "updated_at_utc": self.updated_at_utc,
+            "run_count": self.run_count,
+            "status_counts": self.status_counts,
+            "runs": [
+                run_state.to_dict()
+                for run_state in self.runs
+            ],
+        }
+
+
+def initialize_run_progress(
+    plan: ControlledIlluminationRunPlan,
+    *,
+    created_at_utc: str,
+) -> ControlledIlluminationProgress:
+    if not isinstance(
+        plan,
+        ControlledIlluminationRunPlan,
+    ):
+        raise ControlledIlluminationRunStateError(
+            "plan must be ControlledIlluminationRunPlan."
+        )
+
+    creation_timestamp = (
+        validate_required_state_timestamp(
+            created_at_utc,
+            "created_at_utc",
+        )
+    )
+
+    run_states = tuple(
+        RunState(
+            run_id=planned_run.run_id,
+            execution_order=(
+                planned_run.execution_order
+            ),
+        )
+        for planned_run in plan.runs
+    )
+
+    return ControlledIlluminationProgress(
+        schema_version=RUN_PROGRESS_SCHEMA_VERSION,
+        experiment_id=plan.experiment_id,
+        run_plan_sha256=(
+            calculate_run_plan_sha256(plan)
+        ),
+        created_at_utc=creation_timestamp,
+        updated_at_utc=creation_timestamp,
+        runs=run_states,
+    )
+
+
+def transition_progress_run(
+    progress: ControlledIlluminationProgress,
+    run_id: str,
+    target_status: RunStatus | str,
+    transitioned_at_utc: str,
+    *,
+    reason: str | None = None,
+) -> ControlledIlluminationProgress:
+    if not isinstance(
+        progress,
+        ControlledIlluminationProgress,
+    ):
+        raise ControlledIlluminationRunStateError(
+            "progress must be "
+            "ControlledIlluminationProgress."
+        )
+
+    current_state = progress.get_run_state(
+        run_id
+    )
+    normalized_target_status = normalize_run_status(
+        target_status
+    )
+
+    if normalized_target_status == RunStatus.RUNNING:
+        running_state = next(
+            (
+                run_state
+                for run_state in progress.runs
+                if run_state.status
+                == RunStatus.RUNNING
+                and run_state.run_id != run_id
+            ),
+            None,
+        )
+
+        if running_state is not None:
+            raise ControlledIlluminationRunStateError(
+                "Another run is already running: "
+                f"{running_state.run_id}"
+            )
+
+    updated_state = transition_run_state(
+        current_state,
+        normalized_target_status,
+        transitioned_at_utc,
+        reason=reason,
+    )
+
+    updated_runs = tuple(
+        updated_state
+        if run_state.run_id == run_id
+        else run_state
+        for run_state in progress.runs
+    )
+
+    return replace(
+        progress,
+        updated_at_utc=transitioned_at_utc,
+        runs=updated_runs,
     )

--- a/benchmarks/experiments/manage_controlled_illumination_run.py
+++ b/benchmarks/experiments/manage_controlled_illumination_run.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from datetime import datetime, timezone
+from pathlib import Path
+
+from benchmarks.experiments.controlled_illumination_run_planner import (
+    ControlledIlluminationRunPlanError,
+    load_run_plan_manifest,
+)
+from benchmarks.experiments.controlled_illumination_run_state import (
+    RUN_PROGRESS_FILE_NAME,
+    ControlledIlluminationProgress,
+    ControlledIlluminationRunStateError,
+    RunStatus,
+    load_or_initialize_run_progress,
+    load_run_progress,
+    save_run_progress_atomic,
+    transition_progress_run,
+)
+
+
+def utc_now() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .isoformat(timespec="microseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def create_argument_parser(
+) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Manage controlled-illumination "
+            "experiment run progress."
+        )
+    )
+
+    parser.add_argument(
+        "--plan",
+        required=True,
+        help="Path to the run_plan.json manifest.",
+    )
+    parser.add_argument(
+        "--progress",
+        help=(
+            "Path to run_progress.json. "
+            "Defaults to the run-plan directory."
+        ),
+    )
+
+    subparsers = parser.add_subparsers(
+        dest="command",
+        required=True,
+    )
+
+    subparsers.add_parser(
+        "init",
+        help=(
+            "Create progress or validate and load "
+            "existing progress."
+        ),
+    )
+    subparsers.add_parser(
+        "status",
+        help="Display experiment progress.",
+    )
+    subparsers.add_parser(
+        "start-next",
+        help="Start the next planned run.",
+    )
+
+    return parser
+
+
+def determine_progress_path(
+    plan_path: Path,
+    progress_argument: str | None,
+) -> Path:
+    if progress_argument is not None:
+        return Path(progress_argument)
+
+    return (
+        plan_path.parent
+        / RUN_PROGRESS_FILE_NAME
+    )
+
+
+def print_progress_summary(
+    progress: ControlledIlluminationProgress,
+    progress_path: Path,
+) -> None:
+    print(f"Experiment: {progress.experiment_id}")
+    print(f"Progress file: {progress_path}")
+    print(f"Total runs: {progress.run_count}")
+
+    for status in RunStatus:
+        print(
+            f"{status.value}: "
+            f"{progress.status_counts[status.value]}"
+        )
+
+    next_run = progress.next_planned_run
+
+    if next_run is None:
+        print("Next planned run: none")
+    else:
+        print(
+            "Next planned run: "
+            f"{next_run.run_id} "
+            f"(order {next_run.execution_order})"
+        )
+
+
+def initialize_progress_command(
+    plan_path: Path,
+    progress_path: Path,
+    *,
+    now_provider: Callable[[], str],
+) -> ControlledIlluminationProgress:
+    plan = load_run_plan_manifest(
+        plan_path
+    )
+    progress_existed = progress_path.is_file()
+
+    progress = load_or_initialize_run_progress(
+        plan,
+        progress_path,
+        created_at_utc=now_provider(),
+    )
+
+    if progress_existed:
+        print(
+            "Existing run progress loaded and "
+            "validated."
+        )
+    else:
+        print("Run progress initialized.")
+
+    print_progress_summary(
+        progress,
+        progress_path,
+    )
+
+    return progress
+
+
+def status_command(
+    plan_path: Path,
+    progress_path: Path,
+) -> ControlledIlluminationProgress:
+    plan = load_run_plan_manifest(
+        plan_path
+    )
+    progress = load_run_progress(
+        progress_path,
+        plan=plan,
+    )
+
+    print_progress_summary(
+        progress,
+        progress_path,
+    )
+
+    return progress
+
+
+def start_next_command(
+    plan_path: Path,
+    progress_path: Path,
+    *,
+    now_provider: Callable[[], str],
+) -> ControlledIlluminationProgress:
+    plan = load_run_plan_manifest(
+        plan_path
+    )
+    progress = load_run_progress(
+        progress_path,
+        plan=plan,
+    )
+
+    running_run = next(
+        (
+            run_state
+            for run_state in progress.runs
+            if run_state.status
+            == RunStatus.RUNNING
+        ),
+        None,
+    )
+
+    if running_run is not None:
+        raise ControlledIlluminationRunStateError(
+            "A run is already running: "
+            f"{running_run.run_id}"
+        )
+
+    next_run = progress.next_planned_run
+
+    if next_run is None:
+        raise ControlledIlluminationRunStateError(
+            "No planned runs remain."
+        )
+
+    updated_progress = transition_progress_run(
+        progress,
+        next_run.run_id,
+        RunStatus.RUNNING,
+        now_provider(),
+    )
+
+    save_run_progress_atomic(
+        updated_progress,
+        progress_path,
+    )
+
+    print(f"Started run: {next_run.run_id}")
+    print(
+        "Execution order: "
+        f"{next_run.execution_order}"
+    )
+
+    return updated_progress
+
+
+def run_cli(
+    arguments: argparse.Namespace,
+    *,
+    now_provider: Callable[[], str] = utc_now,
+) -> int:
+    plan_path = Path(arguments.plan)
+    progress_path = determine_progress_path(
+        plan_path,
+        arguments.progress,
+    )
+
+    if arguments.command == "init":
+        initialize_progress_command(
+            plan_path,
+            progress_path,
+            now_provider=now_provider,
+        )
+        return 0
+
+    if arguments.command == "status":
+        status_command(
+            plan_path,
+            progress_path,
+        )
+        return 0
+
+    if arguments.command == "start-next":
+        start_next_command(
+            plan_path,
+            progress_path,
+            now_provider=now_provider,
+        )
+        return 0
+
+    raise ControlledIlluminationRunStateError(
+        f"Unsupported command: {arguments.command}"
+    )
+
+
+def main() -> None:
+    parser = create_argument_parser()
+    arguments = parser.parse_args()
+
+    try:
+        exit_code = run_cli(arguments)
+    except (
+        ControlledIlluminationRunPlanError,
+        ControlledIlluminationRunStateError,
+        OSError,
+    ) as error:
+        parser.error(str(error))
+
+    raise SystemExit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/experiments/manage_controlled_illumination_run.py
+++ b/benchmarks/experiments/manage_controlled_illumination_run.py
@@ -4,6 +4,7 @@ import argparse
 from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
+from collections.abc import Callable
 
 from benchmarks.experiments.controlled_illumination_run_planner import (
     ControlledIlluminationRunPlanError,
@@ -55,7 +56,6 @@ def create_argument_parser(
         dest="command",
         required=True,
     )
-
     subparsers.add_parser(
         "init",
         help=(
@@ -70,6 +70,59 @@ def create_argument_parser(
     subparsers.add_parser(
         "start-next",
         help="Start the next planned run.",
+    )
+
+    complete_parser = subparsers.add_parser(
+        "complete",
+        help="Mark a running run as completed.",
+    )
+    complete_parser.add_argument(
+        "--run-id",
+        required=True,
+        help="Run identifier to complete.",
+    )
+
+    fail_parser = subparsers.add_parser(
+        "fail",
+        help="Mark a running run as failed.",
+    )
+    fail_parser.add_argument(
+        "--run-id",
+        required=True,
+        help="Run identifier to fail.",
+    )
+    fail_parser.add_argument(
+        "--reason",
+        required=True,
+        help="Failure reason.",
+    )
+
+    skip_parser = subparsers.add_parser(
+        "skip",
+        help="Skip a planned run.",
+    )
+    skip_parser.add_argument(
+        "--run-id",
+        required=True,
+        help="Run identifier to skip.",
+    )
+    skip_parser.add_argument(
+        "--reason",
+        required=True,
+        help="Skip reason.",
+    )
+
+    replan_parser = subparsers.add_parser(
+        "replan",
+        help=(
+            "Return a failed or skipped run "
+            "to planned status."
+        ),
+    )
+    replan_parser.add_argument(
+        "--run-id",
+        required=True,
+        help="Run identifier to replan.",
     )
 
     return parser
@@ -224,6 +277,43 @@ def start_next_command(
 
     return updated_progress
 
+def update_run_status_command(
+    plan_path: Path,
+    progress_path: Path,
+    *,
+    run_id: str,
+    target_status: RunStatus,
+    now_provider: Callable[[], str],
+    reason: str | None = None,
+) -> ControlledIlluminationProgress:
+    plan = load_run_plan_manifest(plan_path)
+    progress = load_run_progress(
+        progress_path,
+        plan=plan,
+    )
+
+    updated_progress = transition_progress_run(
+        progress,
+        run_id,
+        target_status,
+        now_provider(),
+        reason=reason,
+    )
+
+    save_run_progress_atomic(
+        updated_progress,
+        progress_path,
+    )
+
+    print(
+        f"Run updated: {run_id} -> "
+        f"{target_status.value}"
+    )
+
+    if reason is not None:
+        print(f"Reason: {reason}")
+
+    return updated_progress
 
 def run_cli(
     arguments: argparse.Namespace,
@@ -255,6 +345,48 @@ def run_cli(
         start_next_command(
             plan_path,
             progress_path,
+            now_provider=now_provider,
+        )
+        return 0
+
+    if arguments.command == "complete":
+        update_run_status_command(
+            plan_path,
+            progress_path,
+            run_id=arguments.run_id,
+            target_status=RunStatus.COMPLETED,
+            now_provider=now_provider,
+        )
+        return 0
+
+    if arguments.command == "fail":
+        update_run_status_command(
+            plan_path,
+            progress_path,
+            run_id=arguments.run_id,
+            target_status=RunStatus.FAILED,
+            now_provider=now_provider,
+            reason=arguments.reason,
+        )
+        return 0
+
+    if arguments.command == "skip":
+        update_run_status_command(
+            plan_path,
+            progress_path,
+            run_id=arguments.run_id,
+            target_status=RunStatus.SKIPPED,
+            now_provider=now_provider,
+            reason=arguments.reason,
+        )
+        return 0
+
+    if arguments.command == "replan":
+        update_run_status_command(
+            plan_path,
+            progress_path,
+            run_id=arguments.run_id,
+            target_status=RunStatus.PLANNED,
             now_provider=now_provider,
         )
         return 0

--- a/benchmarks/experiments/manage_controlled_illumination_run.py
+++ b/benchmarks/experiments/manage_controlled_illumination_run.py
@@ -4,7 +4,6 @@ import argparse
 from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
-from collections.abc import Callable
 
 from benchmarks.experiments.controlled_illumination_run_planner import (
     ControlledIlluminationRunPlanError,

--- a/benchmarks/experiments/tests/test_controlled_illumination_run_planner.py
+++ b/benchmarks/experiments/tests/test_controlled_illumination_run_planner.py
@@ -15,6 +15,9 @@ from benchmarks.experiments.controlled_illumination_run_planner import (
     build_run_conditions,
     build_run_plan,
     write_run_plan_manifests_atomic,
+    load_run_plan_manifest,
+    planned_run_from_dict,
+    run_plan_from_dict,
 )
 
 
@@ -508,6 +511,114 @@ class ControlledIlluminationRunPlannerTests(
                 ),
             )
 
+    def test_planned_run_round_trip(
+        self,
+    ) -> None:
+        plan = build_run_plan(
+            self.build_small_matrix_config(),
+            experiment_id="experiment-load",
+            generated_at_utc=(
+                "2026-08-23T09:00:00Z"
+            ),
+        )
+
+        original_run = plan.runs[0]
+        loaded_run = planned_run_from_dict(
+            original_run.to_dict()
+        )
+
+        self.assertEqual(
+            loaded_run.to_dict(),
+            original_run.to_dict(),
+        )
+
+    def test_run_plan_round_trip(
+        self,
+    ) -> None:
+        plan = build_run_plan(
+            self.build_small_matrix_config(),
+            experiment_id="experiment-load",
+            generated_at_utc=(
+                "2026-08-23T09:00:00Z"
+            ),
+        )
+
+        loaded_plan = run_plan_from_dict(
+            plan.to_dict()
+        )
+
+        self.assertEqual(
+            loaded_plan.to_dict(),
+            plan.to_dict(),
+        )
+
+    def test_written_manifest_can_be_loaded(
+        self,
+    ) -> None:
+        plan = build_run_plan(
+            self.build_small_matrix_config(),
+            experiment_id="experiment-load",
+            generated_at_utc=(
+                "2026-08-23T09:00:00Z"
+            ),
+        )
+
+        with TemporaryDirectory() as temporary:
+            json_path, _ = (
+                write_run_plan_manifests_atomic(
+                    plan,
+                    temporary,
+                )
+            )
+            loaded_plan = load_run_plan_manifest(
+                json_path
+            )
+
+        self.assertEqual(
+            loaded_plan.to_dict(),
+            plan.to_dict(),
+        )
+
+    def test_modified_manifest_run_count_is_rejected(
+        self,
+    ) -> None:
+        plan = build_run_plan(
+            self.build_small_matrix_config(),
+            experiment_id="experiment-load",
+            generated_at_utc=(
+                "2026-08-23T09:00:00Z"
+            ),
+        )
+        plan_data = plan.to_dict()
+        plan_data["run_count"] = 999
+
+        with self.assertRaisesRegex(
+            ControlledIlluminationRunPlanError,
+            "run_count",
+        ):
+            run_plan_from_dict(
+                plan_data
+            )
+
+    def test_invalid_manifest_json_is_rejected(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary:
+            manifest_path = (
+                Path(temporary) / "run_plan.json"
+            )
+            manifest_path.write_text(
+                "{invalid-json",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(
+                ControlledIlluminationRunPlanError,
+                "could not be loaded",
+            ):
+                load_run_plan_manifest(
+                    manifest_path
+                )
 
 if __name__ == "__main__":
     unittest.main()

--- a/benchmarks/experiments/tests/test_controlled_illumination_run_state.py
+++ b/benchmarks/experiments/tests/test_controlled_illumination_run_state.py
@@ -729,6 +729,58 @@ class ControlledIlluminationRunStateTests(
                 load_run_progress(
                     progress_path
                 )
+    def test_finished_timestamp_before_started_is_rejected(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(
+            ControlledIlluminationRunStateError,
+            "finished_at_utc must not be earlier",
+        ):
+            RunState(
+                run_id="run-chronology",
+                execution_order=1,
+                status=RunStatus.COMPLETED,
+                attempt_count=1,
+                started_at_utc=(
+                    "2026-08-23T10:00:00Z"
+                ),
+                finished_at_utc=(
+                    "2026-08-23T09:59:59Z"
+                ),
+                failure_reason=None,
+                skip_reason=None,
+            )
+
+    def test_progress_update_before_creation_is_rejected(
+        self,
+    ) -> None:
+        planned_run = RunState(
+            run_id="run-chronology",
+            execution_order=1,
+            status=RunStatus.PLANNED,
+            attempt_count=0,
+            started_at_utc=None,
+            finished_at_utc=None,
+            failure_reason=None,
+            skip_reason=None,
+        )
+
+        with self.assertRaisesRegex(
+            ControlledIlluminationRunStateError,
+            "updated_at_utc must not be earlier",
+        ):
+            ControlledIlluminationProgress(
+                schema_version=1,
+                experiment_id="experiment-chronology",
+                run_plan_sha256="a" * 64,
+                created_at_utc=(
+                    "2026-08-23T10:00:00Z"
+                ),
+                updated_at_utc=(
+                    "2026-08-23T09:59:59Z"
+                ),
+                runs=(planned_run,),
+            )
 
 
 if __name__ == "__main__":

--- a/benchmarks/experiments/tests/test_controlled_illumination_run_state.py
+++ b/benchmarks/experiments/tests/test_controlled_illumination_run_state.py
@@ -782,6 +782,40 @@ class ControlledIlluminationRunStateTests(
                 runs=(planned_run,),
             )
 
+    def test_progress_transition_rejects_earlier_timestamp(
+            self,
+    ) -> None:
+        progress = initialize_run_progress(
+            self.build_run_plan(),
+            created_at_utc=(
+                "2026-08-23T09:30:00Z"
+            ),
+        )
+
+        progress = transition_progress_run(
+            progress,
+            "experiment-progress-run-0001",
+            RunStatus.RUNNING,
+            STARTED_AT,
+        )
+
+        progress = transition_progress_run(
+            progress,
+            "experiment-progress-run-0001",
+            RunStatus.COMPLETED,
+            FINISHED_AT,
+        )
+
+        with self.assertRaisesRegex(
+                ControlledIlluminationRunStateError,
+                "progress.updated_at_utc",
+        ):
+            transition_progress_run(
+                progress,
+                "experiment-progress-run-0002",
+                RunStatus.RUNNING,
+                "2026-08-23T10:04:00Z",
+            )
 
 if __name__ == "__main__":
     unittest.main()

--- a/benchmarks/experiments/tests/test_controlled_illumination_run_state.py
+++ b/benchmarks/experiments/tests/test_controlled_illumination_run_state.py
@@ -2,10 +2,21 @@ from __future__ import annotations
 
 import unittest
 
+from benchmarks.experiments.controlled_illumination_metadata import (
+    ResolutionMetadata,
+)
+from benchmarks.experiments.controlled_illumination_run_planner import (
+    ControlledIlluminationRunPlan,
+    PlannedRun,
+)
 from benchmarks.experiments.controlled_illumination_run_state import (
+    ControlledIlluminationProgress,
     ControlledIlluminationRunStateError,
     RunState,
     RunStatus,
+    calculate_run_plan_sha256,
+    initialize_run_progress,
+    transition_progress_run,
     transition_run_state,
 )
 
@@ -239,6 +250,234 @@ class ControlledIlluminationRunStateTests(
                 attempt_count=1,
                 started_at_utc=STARTED_AT,
                 finished_at_utc=FINISHED_AT,
+            )
+
+    def build_run_plan(
+        self,
+    ) -> ControlledIlluminationRunPlan:
+        planned_runs = tuple(
+            PlannedRun(
+                execution_order=execution_order,
+                experiment_id="experiment-progress",
+                run_id=run_id,
+                phase="constant_lux",
+                platform="desktop",
+                architecture="pure_python",
+                algorithm="original",
+                resolution=ResolutionMetadata(
+                    width=640,
+                    height=480,
+                ),
+                trial_number=execution_order,
+                incidence_angle_degrees=0.0,
+                target_illuminance_lux=50.0,
+                source_output_setting=None,
+                target_fps=30.0,
+                frame_deadline_ms=1000.0 / 30.0,
+            )
+            for execution_order, run_id in (
+                (1, "experiment-progress-run-0001"),
+                (2, "experiment-progress-run-0002"),
+            )
+        )
+
+        return ControlledIlluminationRunPlan(
+            schema_version=1,
+            generated_at_utc=(
+                "2026-08-23T09:00:00Z"
+            ),
+            experiment_id="experiment-progress",
+            randomized=False,
+            randomization_seed=20260821,
+            runs=planned_runs,
+        )
+
+    def test_progress_is_initialized_from_plan(
+            self,
+    ) -> None:
+        plan = self.build_run_plan()
+
+        progress = initialize_run_progress(
+            plan,
+            created_at_utc=(
+                "2026-08-23T09:30:00Z"
+            ),
+        )
+
+        self.assertEqual(progress.run_count, 2)
+        self.assertEqual(
+            progress.experiment_id,
+            plan.experiment_id,
+        )
+        self.assertEqual(
+            len(progress.run_plan_sha256),
+            64,
+        )
+        self.assertEqual(
+            progress.next_planned_run.run_id,
+            "experiment-progress-run-0001",
+        )
+
+    def test_run_plan_hash_is_deterministic(
+            self,
+    ) -> None:
+        plan = self.build_run_plan()
+
+        self.assertEqual(
+            calculate_run_plan_sha256(plan),
+            calculate_run_plan_sha256(plan),
+        )
+
+    def test_progress_transition_updates_run(
+            self,
+    ) -> None:
+        progress = initialize_run_progress(
+            self.build_run_plan(),
+            created_at_utc=(
+                "2026-08-23T09:30:00Z"
+            ),
+        )
+
+        updated = transition_progress_run(
+            progress,
+            "experiment-progress-run-0001",
+            RunStatus.RUNNING,
+            STARTED_AT,
+        )
+
+        first_run = updated.get_run_state(
+            "experiment-progress-run-0001"
+        )
+
+        self.assertEqual(
+            first_run.status,
+            RunStatus.RUNNING,
+        )
+        self.assertEqual(
+            updated.updated_at_utc,
+            STARTED_AT,
+        )
+        self.assertEqual(
+            updated.next_planned_run.run_id,
+            "experiment-progress-run-0002",
+        )
+
+    def test_only_one_run_can_be_running(
+            self,
+    ) -> None:
+        progress = initialize_run_progress(
+            self.build_run_plan(),
+            created_at_utc=(
+                "2026-08-23T09:30:00Z"
+            ),
+        )
+        progress = transition_progress_run(
+            progress,
+            "experiment-progress-run-0001",
+            RunStatus.RUNNING,
+            STARTED_AT,
+        )
+
+        with self.assertRaisesRegex(
+                ControlledIlluminationRunStateError,
+                "already running",
+        ):
+            transition_progress_run(
+                progress,
+                "experiment-progress-run-0002",
+                RunStatus.RUNNING,
+                "2026-08-23T10:01:00Z",
+            )
+
+    def test_unknown_run_id_is_rejected(
+            self,
+    ) -> None:
+        progress = initialize_run_progress(
+            self.build_run_plan(),
+            created_at_utc=(
+                "2026-08-23T09:30:00Z"
+            ),
+        )
+
+        with self.assertRaisesRegex(
+                ControlledIlluminationRunStateError,
+                "Unknown run ID",
+        ):
+            progress.get_run_state(
+                "unknown-run"
+            )
+
+    def test_completed_run_advances_next_planned(
+            self,
+    ) -> None:
+        progress = initialize_run_progress(
+            self.build_run_plan(),
+            created_at_utc=(
+                "2026-08-23T09:30:00Z"
+            ),
+        )
+        progress = transition_progress_run(
+            progress,
+            "experiment-progress-run-0001",
+            RunStatus.RUNNING,
+            STARTED_AT,
+        )
+        progress = transition_progress_run(
+            progress,
+            "experiment-progress-run-0001",
+            RunStatus.COMPLETED,
+            FINISHED_AT,
+        )
+
+        self.assertEqual(
+            progress.next_planned_run.run_id,
+            "experiment-progress-run-0002",
+        )
+        self.assertEqual(
+            progress.status_counts["completed"],
+            1,
+        )
+        self.assertEqual(
+            progress.status_counts["planned"],
+            1,
+        )
+
+    def test_progress_is_serialized(
+            self,
+    ) -> None:
+        progress = initialize_run_progress(
+            self.build_run_plan(),
+            created_at_utc=(
+                "2026-08-23T09:30:00Z"
+            ),
+        )
+
+        serialized = progress.to_dict()
+
+        self.assertEqual(
+            serialized["run_count"],
+            2,
+        )
+        self.assertEqual(
+            serialized["status_counts"]["planned"],
+            2,
+        )
+        self.assertEqual(
+            len(serialized["runs"]),
+            2,
+        )
+
+    def test_invalid_plan_type_is_rejected(
+            self,
+    ) -> None:
+        with self.assertRaises(
+                ControlledIlluminationRunStateError
+        ):
+            initialize_run_progress(
+                "invalid-plan",  # type: ignore[arg-type]
+                created_at_utc=(
+                    "2026-08-23T09:30:00Z"
+                ),
             )
 
 

--- a/benchmarks/experiments/tests/test_controlled_illumination_run_state.py
+++ b/benchmarks/experiments/tests/test_controlled_illumination_run_state.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import json
 import unittest
+from dataclasses import replace
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 from benchmarks.experiments.controlled_illumination_metadata import (
     ResolutionMetadata,
@@ -18,6 +22,10 @@ from benchmarks.experiments.controlled_illumination_run_state import (
     initialize_run_progress,
     transition_progress_run,
     transition_run_state,
+    load_or_initialize_run_progress,
+    load_run_progress,
+    progress_from_dict,
+    save_run_progress_atomic,
 )
 
 
@@ -479,6 +487,248 @@ class ControlledIlluminationRunStateTests(
                     "2026-08-23T09:30:00Z"
                 ),
             )
+    def test_progress_save_and_load_round_trip(
+        self,
+    ) -> None:
+        plan = self.build_run_plan()
+        progress = initialize_run_progress(
+            plan,
+            created_at_utc=(
+                "2026-08-23T09:30:00Z"
+            ),
+        )
+
+        with TemporaryDirectory() as temporary:
+            progress_path = (
+                Path(temporary)
+                / "run_progress.json"
+            )
+
+            save_run_progress_atomic(
+                progress,
+                progress_path,
+            )
+            loaded = load_run_progress(
+                progress_path,
+                plan=plan,
+            )
+
+        self.assertEqual(
+            loaded.to_dict(),
+            progress.to_dict(),
+        )
+
+    def test_atomic_save_removes_temporary_file(
+        self,
+    ) -> None:
+        progress = initialize_run_progress(
+            self.build_run_plan(),
+            created_at_utc=(
+                "2026-08-23T09:30:00Z"
+            ),
+        )
+
+        with TemporaryDirectory() as temporary:
+            temporary_path = Path(temporary)
+            progress_path = (
+                temporary_path
+                / "run_progress.json"
+            )
+
+            save_run_progress_atomic(
+                progress,
+                progress_path,
+            )
+
+            temporary_files = [
+                path
+                for path in temporary_path.iterdir()
+                if path.name.endswith(".tmp")
+            ]
+
+            self.assertEqual(
+                temporary_files,
+                [],
+            )
+
+    def test_load_or_initialize_creates_progress(
+        self,
+    ) -> None:
+        plan = self.build_run_plan()
+
+        with TemporaryDirectory() as temporary:
+            progress_path = (
+                Path(temporary)
+                / "run_progress.json"
+            )
+
+            progress = (
+                load_or_initialize_run_progress(
+                    plan,
+                    progress_path,
+                    created_at_utc=(
+                        "2026-08-23T09:30:00Z"
+                    ),
+                )
+            )
+
+            self.assertTrue(
+                progress_path.is_file()
+            )
+            self.assertEqual(
+                progress.run_count,
+                2,
+            )
+
+    def test_load_or_initialize_resumes_progress(
+        self,
+    ) -> None:
+        plan = self.build_run_plan()
+
+        with TemporaryDirectory() as temporary:
+            progress_path = (
+                Path(temporary)
+                / "run_progress.json"
+            )
+
+            progress = (
+                load_or_initialize_run_progress(
+                    plan,
+                    progress_path,
+                    created_at_utc=(
+                        "2026-08-23T09:30:00Z"
+                    ),
+                )
+            )
+            progress = transition_progress_run(
+                progress,
+                "experiment-progress-run-0001",
+                RunStatus.RUNNING,
+                STARTED_AT,
+            )
+            save_run_progress_atomic(
+                progress,
+                progress_path,
+            )
+
+            resumed = (
+                load_or_initialize_run_progress(
+                    plan,
+                    progress_path,
+                    created_at_utc=(
+                        "2026-08-23T11:00:00Z"
+                    ),
+                )
+            )
+
+        self.assertEqual(
+            resumed.get_run_state(
+                "experiment-progress-run-0001"
+            ).status,
+            RunStatus.RUNNING,
+        )
+        self.assertEqual(
+            resumed.created_at_utc,
+            "2026-08-23T09:30:00Z",
+        )
+
+    def test_different_run_plan_is_rejected(
+        self,
+    ) -> None:
+        plan = self.build_run_plan()
+        different_plan = replace(
+            plan,
+            randomization_seed=20260822,
+        )
+        progress = initialize_run_progress(
+            plan,
+            created_at_utc=(
+                "2026-08-23T09:30:00Z"
+            ),
+        )
+
+        with TemporaryDirectory() as temporary:
+            progress_path = (
+                Path(temporary)
+                / "run_progress.json"
+            )
+
+            save_run_progress_atomic(
+                progress,
+                progress_path,
+            )
+
+            with self.assertRaisesRegex(
+                ControlledIlluminationRunStateError,
+                "different run plan",
+            ):
+                load_run_progress(
+                    progress_path,
+                    plan=different_plan,
+                )
+
+    def test_modified_run_count_is_rejected(
+        self,
+    ) -> None:
+        progress = initialize_run_progress(
+            self.build_run_plan(),
+            created_at_utc=(
+                "2026-08-23T09:30:00Z"
+            ),
+        )
+        progress_data = progress.to_dict()
+        progress_data["run_count"] = 999
+
+        with self.assertRaisesRegex(
+            ControlledIlluminationRunStateError,
+            "run_count",
+        ):
+            progress_from_dict(
+                progress_data
+            )
+
+    def test_modified_status_counts_are_rejected(
+        self,
+    ) -> None:
+        progress = initialize_run_progress(
+            self.build_run_plan(),
+            created_at_utc=(
+                "2026-08-23T09:30:00Z"
+            ),
+        )
+        progress_data = progress.to_dict()
+        progress_data["status_counts"][
+            "planned"
+        ] = 999
+
+        with self.assertRaisesRegex(
+            ControlledIlluminationRunStateError,
+            "status_counts",
+        ):
+            progress_from_dict(
+                progress_data
+            )
+
+    def test_invalid_progress_json_is_rejected(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary:
+            progress_path = (
+                Path(temporary)
+                / "run_progress.json"
+            )
+            progress_path.write_text(
+                "{invalid-json",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(
+                ControlledIlluminationRunStateError,
+                "could not be loaded",
+            ):
+                load_run_progress(
+                    progress_path
+                )
 
 
 if __name__ == "__main__":

--- a/benchmarks/experiments/tests/test_controlled_illumination_run_state.py
+++ b/benchmarks/experiments/tests/test_controlled_illumination_run_state.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import unittest
+
+from benchmarks.experiments.controlled_illumination_run_state import (
+    ControlledIlluminationRunStateError,
+    RunState,
+    RunStatus,
+    transition_run_state,
+)
+
+
+STARTED_AT = "2026-08-23T10:00:00Z"
+FINISHED_AT = "2026-08-23T10:05:00Z"
+
+
+class ControlledIlluminationRunStateTests(
+    unittest.TestCase
+):
+    def setUp(self) -> None:
+        self.planned_state = RunState(
+            run_id="experiment-run-0001",
+            execution_order=1,
+        )
+
+    def start_run(self) -> RunState:
+        return transition_run_state(
+            self.planned_state,
+            RunStatus.RUNNING,
+            STARTED_AT,
+        )
+
+    def test_planned_state_defaults(
+        self,
+    ) -> None:
+        self.assertEqual(
+            self.planned_state.status,
+            RunStatus.PLANNED,
+        )
+        self.assertEqual(
+            self.planned_state.attempt_count,
+            0,
+        )
+        self.assertIsNone(
+            self.planned_state.started_at_utc
+        )
+
+    def test_string_status_is_normalized(
+        self,
+    ) -> None:
+        state = RunState(
+            run_id="experiment-run-0001",
+            execution_order=1,
+            status="planned",  # type: ignore[arg-type]
+        )
+
+        self.assertEqual(
+            state.status,
+            RunStatus.PLANNED,
+        )
+
+    def test_planned_run_can_start(
+        self,
+    ) -> None:
+        running = self.start_run()
+
+        self.assertEqual(
+            running.status,
+            RunStatus.RUNNING,
+        )
+        self.assertEqual(running.attempt_count, 1)
+        self.assertEqual(
+            running.started_at_utc,
+            STARTED_AT,
+        )
+
+    def test_running_run_can_complete(
+        self,
+    ) -> None:
+        completed = transition_run_state(
+            self.start_run(),
+            RunStatus.COMPLETED,
+            FINISHED_AT,
+        )
+
+        self.assertEqual(
+            completed.status,
+            RunStatus.COMPLETED,
+        )
+        self.assertEqual(
+            completed.finished_at_utc,
+            FINISHED_AT,
+        )
+
+    def test_running_run_can_fail(
+        self,
+    ) -> None:
+        failed = transition_run_state(
+            self.start_run(),
+            RunStatus.FAILED,
+            FINISHED_AT,
+            reason="Camera disconnected.",
+        )
+
+        self.assertEqual(
+            failed.status,
+            RunStatus.FAILED,
+        )
+        self.assertEqual(
+            failed.failure_reason,
+            "Camera disconnected.",
+        )
+
+    def test_failed_transition_requires_reason(
+        self,
+    ) -> None:
+        with self.assertRaises(
+            ControlledIlluminationRunStateError
+        ):
+            transition_run_state(
+                self.start_run(),
+                RunStatus.FAILED,
+                FINISHED_AT,
+            )
+
+    def test_planned_run_can_be_skipped(
+        self,
+    ) -> None:
+        skipped = transition_run_state(
+            self.planned_state,
+            RunStatus.SKIPPED,
+            FINISHED_AT,
+            reason="Platform unavailable.",
+        )
+
+        self.assertEqual(
+            skipped.status,
+            RunStatus.SKIPPED,
+        )
+        self.assertEqual(
+            skipped.skip_reason,
+            "Platform unavailable.",
+        )
+
+    def test_skipped_transition_requires_reason(
+        self,
+    ) -> None:
+        with self.assertRaises(
+            ControlledIlluminationRunStateError
+        ):
+            transition_run_state(
+                self.planned_state,
+                RunStatus.SKIPPED,
+                FINISHED_AT,
+            )
+
+    def test_invalid_transition_is_rejected(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(
+            ControlledIlluminationRunStateError,
+            "Invalid run-state transition",
+        ):
+            transition_run_state(
+                self.planned_state,
+                RunStatus.COMPLETED,
+                FINISHED_AT,
+            )
+
+    def test_reason_is_rejected_when_not_allowed(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(
+            ControlledIlluminationRunStateError,
+            "reason is only allowed",
+        ):
+            transition_run_state(
+                self.planned_state,
+                RunStatus.RUNNING,
+                STARTED_AT,
+                reason="Unexpected reason.",
+            )
+
+    def test_failed_run_can_be_replanned(
+        self,
+    ) -> None:
+        failed = transition_run_state(
+            self.start_run(),
+            RunStatus.FAILED,
+            FINISHED_AT,
+            reason="Temporary camera error.",
+        )
+        replanned = transition_run_state(
+            failed,
+            RunStatus.PLANNED,
+            "2026-08-23T10:06:00Z",
+        )
+        restarted = transition_run_state(
+            replanned,
+            RunStatus.RUNNING,
+            "2026-08-23T10:07:00Z",
+        )
+
+        self.assertEqual(
+            replanned.status,
+            RunStatus.PLANNED,
+        )
+        self.assertIsNone(
+            replanned.failure_reason
+        )
+        self.assertEqual(
+            restarted.attempt_count,
+            2,
+        )
+
+    def test_invalid_timestamp_is_rejected(
+        self,
+    ) -> None:
+        with self.assertRaises(
+            ControlledIlluminationRunStateError
+        ):
+            transition_run_state(
+                self.planned_state,
+                RunStatus.RUNNING,
+                "invalid-timestamp",
+            )
+
+    def test_inconsistent_running_state_is_rejected(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(
+            ControlledIlluminationRunStateError,
+            "Running run fields are inconsistent",
+        ):
+            RunState(
+                run_id="experiment-run-0001",
+                execution_order=1,
+                status=RunStatus.RUNNING,
+                attempt_count=1,
+                started_at_utc=STARTED_AT,
+                finished_at_utc=FINISHED_AT,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/experiments/tests/test_manage_controlled_illumination_run.py
+++ b/benchmarks/experiments/tests/test_manage_controlled_illumination_run.py
@@ -28,6 +28,10 @@ from benchmarks.experiments.manage_controlled_illumination_run import (
 
 CREATED_AT = "2026-08-23T09:30:00Z"
 STARTED_AT = "2026-08-23T10:00:00Z"
+COMPLETED_AT = "2026-08-23T10:05:00Z"
+FAILED_AT = "2026-08-23T10:06:00Z"
+SKIPPED_AT = "2026-08-23T10:07:00Z"
+REPLANNED_AT = "2026-08-23T10:08:00Z"
 
 
 class ManageControlledIlluminationRunTests(
@@ -88,6 +92,7 @@ class ManageControlledIlluminationRunTests(
         plan_path: Path,
         progress_path: Path,
         command: str,
+        *command_arguments: str,
     ):
         return create_argument_parser().parse_args(
             [
@@ -96,6 +101,7 @@ class ManageControlledIlluminationRunTests(
                 "--progress",
                 str(progress_path),
                 command,
+                *command_arguments,
             ]
         )
 
@@ -337,6 +343,304 @@ class ManageControlledIlluminationRunTests(
                         now_provider=lambda: (
                             "2026-08-23T10:01:00Z"
                         ),
+                    )
+    def test_complete_marks_running_run_completed(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary:
+            temporary_path = Path(temporary)
+            plan, plan_path = self.create_run_plan(
+                temporary_path
+            )
+            progress_path = (
+                temporary_path / "run_progress.json"
+            )
+
+            init_arguments = self.parse_arguments(
+                plan_path,
+                progress_path,
+                "init",
+            )
+            start_arguments = self.parse_arguments(
+                plan_path,
+                progress_path,
+                "start-next",
+            )
+            complete_arguments = self.parse_arguments(
+                plan_path,
+                progress_path,
+                "complete",
+                "--run-id",
+                "experiment-cli-run-0001",
+            )
+
+            with redirect_stdout(StringIO()):
+                run_cli(
+                    init_arguments,
+                    now_provider=lambda: CREATED_AT,
+                )
+                run_cli(
+                    start_arguments,
+                    now_provider=lambda: STARTED_AT,
+                )
+                exit_code = run_cli(
+                    complete_arguments,
+                    now_provider=lambda: COMPLETED_AT,
+                )
+
+            progress = load_run_progress(
+                progress_path,
+                plan=plan,
+            )
+            first_run = progress.get_run_state(
+                "experiment-cli-run-0001"
+            )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(
+            first_run.status,
+            RunStatus.COMPLETED,
+        )
+        self.assertEqual(
+            first_run.finished_at_utc,
+            COMPLETED_AT,
+        )
+
+    def test_fail_records_failure_reason(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary:
+            temporary_path = Path(temporary)
+            plan, plan_path = self.create_run_plan(
+                temporary_path
+            )
+            progress_path = (
+                temporary_path / "run_progress.json"
+            )
+
+            init_arguments = self.parse_arguments(
+                plan_path,
+                progress_path,
+                "init",
+            )
+            start_arguments = self.parse_arguments(
+                plan_path,
+                progress_path,
+                "start-next",
+            )
+            fail_arguments = self.parse_arguments(
+                plan_path,
+                progress_path,
+                "fail",
+                "--run-id",
+                "experiment-cli-run-0001",
+                "--reason",
+                "Camera disconnected.",
+            )
+
+            with redirect_stdout(StringIO()):
+                run_cli(
+                    init_arguments,
+                    now_provider=lambda: CREATED_AT,
+                )
+                run_cli(
+                    start_arguments,
+                    now_provider=lambda: STARTED_AT,
+                )
+                exit_code = run_cli(
+                    fail_arguments,
+                    now_provider=lambda: FAILED_AT,
+                )
+
+            progress = load_run_progress(
+                progress_path,
+                plan=plan,
+            )
+            first_run = progress.get_run_state(
+                "experiment-cli-run-0001"
+            )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(
+            first_run.status,
+            RunStatus.FAILED,
+        )
+        self.assertEqual(
+            first_run.failure_reason,
+            "Camera disconnected.",
+        )
+
+    def test_skip_records_skip_reason(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary:
+            temporary_path = Path(temporary)
+            plan, plan_path = self.create_run_plan(
+                temporary_path
+            )
+            progress_path = (
+                temporary_path / "run_progress.json"
+            )
+
+            init_arguments = self.parse_arguments(
+                plan_path,
+                progress_path,
+                "init",
+            )
+            skip_arguments = self.parse_arguments(
+                plan_path,
+                progress_path,
+                "skip",
+                "--run-id",
+                "experiment-cli-run-0002",
+                "--reason",
+                "Lighting unavailable.",
+            )
+
+            with redirect_stdout(StringIO()):
+                run_cli(
+                    init_arguments,
+                    now_provider=lambda: CREATED_AT,
+                )
+                exit_code = run_cli(
+                    skip_arguments,
+                    now_provider=lambda: SKIPPED_AT,
+                )
+
+            progress = load_run_progress(
+                progress_path,
+                plan=plan,
+            )
+            second_run = progress.get_run_state(
+                "experiment-cli-run-0002"
+            )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(
+            second_run.status,
+            RunStatus.SKIPPED,
+        )
+        self.assertEqual(
+            second_run.skip_reason,
+            "Lighting unavailable.",
+        )
+
+    def test_replan_returns_failed_run_to_planned(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary:
+            temporary_path = Path(temporary)
+            plan, plan_path = self.create_run_plan(
+                temporary_path
+            )
+            progress_path = (
+                temporary_path / "run_progress.json"
+            )
+
+            init_arguments = self.parse_arguments(
+                plan_path,
+                progress_path,
+                "init",
+            )
+            start_arguments = self.parse_arguments(
+                plan_path,
+                progress_path,
+                "start-next",
+            )
+            fail_arguments = self.parse_arguments(
+                plan_path,
+                progress_path,
+                "fail",
+                "--run-id",
+                "experiment-cli-run-0001",
+                "--reason",
+                "Temporary failure.",
+            )
+            replan_arguments = self.parse_arguments(
+                plan_path,
+                progress_path,
+                "replan",
+                "--run-id",
+                "experiment-cli-run-0001",
+            )
+
+            with redirect_stdout(StringIO()):
+                run_cli(
+                    init_arguments,
+                    now_provider=lambda: CREATED_AT,
+                )
+                run_cli(
+                    start_arguments,
+                    now_provider=lambda: STARTED_AT,
+                )
+                run_cli(
+                    fail_arguments,
+                    now_provider=lambda: FAILED_AT,
+                )
+                exit_code = run_cli(
+                    replan_arguments,
+                    now_provider=lambda: REPLANNED_AT,
+                )
+
+            progress = load_run_progress(
+                progress_path,
+                plan=plan,
+            )
+            first_run = progress.get_run_state(
+                "experiment-cli-run-0001"
+            )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(
+            first_run.status,
+            RunStatus.PLANNED,
+        )
+        self.assertIsNone(
+            first_run.failure_reason
+        )
+        self.assertEqual(
+            first_run.attempt_count,
+            1,
+        )
+
+    def test_complete_rejects_planned_run(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary:
+            temporary_path = Path(temporary)
+            _, plan_path = self.create_run_plan(
+                temporary_path
+            )
+            progress_path = (
+                temporary_path / "run_progress.json"
+            )
+
+            init_arguments = self.parse_arguments(
+                plan_path,
+                progress_path,
+                "init",
+            )
+            complete_arguments = self.parse_arguments(
+                plan_path,
+                progress_path,
+                "complete",
+                "--run-id",
+                "experiment-cli-run-0001",
+            )
+
+            with redirect_stdout(StringIO()):
+                run_cli(
+                    init_arguments,
+                    now_provider=lambda: CREATED_AT,
+                )
+
+            with self.assertRaises(
+                ControlledIlluminationRunStateError
+            ):
+                with redirect_stdout(StringIO()):
+                    run_cli(
+                        complete_arguments,
+                        now_provider=lambda: COMPLETED_AT,
                     )
 
 

--- a/benchmarks/experiments/tests/test_manage_controlled_illumination_run.py
+++ b/benchmarks/experiments/tests/test_manage_controlled_illumination_run.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from benchmarks.experiments.controlled_illumination_metadata import (
+    ResolutionMetadata,
+)
+from benchmarks.experiments.controlled_illumination_run_planner import (
+    ControlledIlluminationRunPlan,
+    PlannedRun,
+    write_run_plan_manifests_atomic,
+)
+from benchmarks.experiments.controlled_illumination_run_state import (
+    ControlledIlluminationRunStateError,
+    RunStatus,
+    load_run_progress,
+)
+from benchmarks.experiments.manage_controlled_illumination_run import (
+    create_argument_parser,
+    determine_progress_path,
+    run_cli,
+)
+
+
+CREATED_AT = "2026-08-23T09:30:00Z"
+STARTED_AT = "2026-08-23T10:00:00Z"
+
+
+class ManageControlledIlluminationRunTests(
+    unittest.TestCase
+):
+    def create_run_plan(
+        self,
+        directory: Path,
+    ) -> tuple[ControlledIlluminationRunPlan, Path]:
+        planned_runs = tuple(
+            PlannedRun(
+                execution_order=execution_order,
+                experiment_id="experiment-cli",
+                run_id=run_id,
+                phase="constant_lux",
+                platform="desktop",
+                architecture="pure_python",
+                algorithm="original",
+                resolution=ResolutionMetadata(
+                    width=640,
+                    height=480,
+                ),
+                trial_number=execution_order,
+                incidence_angle_degrees=0.0,
+                target_illuminance_lux=50.0,
+                source_output_setting=None,
+                target_fps=30.0,
+                frame_deadline_ms=1000.0 / 30.0,
+            )
+            for execution_order, run_id in (
+                (1, "experiment-cli-run-0001"),
+                (2, "experiment-cli-run-0002"),
+            )
+        )
+
+        plan = ControlledIlluminationRunPlan(
+            schema_version=1,
+            generated_at_utc=(
+                "2026-08-23T09:00:00Z"
+            ),
+            experiment_id="experiment-cli",
+            randomized=False,
+            randomization_seed=20260821,
+            runs=planned_runs,
+        )
+
+        json_path, _ = (
+            write_run_plan_manifests_atomic(
+                plan,
+                directory,
+            )
+        )
+
+        return plan, json_path
+
+    def parse_arguments(
+        self,
+        plan_path: Path,
+        progress_path: Path,
+        command: str,
+    ):
+        return create_argument_parser().parse_args(
+            [
+                "--plan",
+                str(plan_path),
+                "--progress",
+                str(progress_path),
+                command,
+            ]
+        )
+
+    def test_default_progress_path(
+        self,
+    ) -> None:
+        plan_path = (
+            Path("experiment")
+            / "run_plan.json"
+        )
+
+        self.assertEqual(
+            determine_progress_path(
+                plan_path,
+                None,
+            ),
+            (
+                Path("experiment")
+                / "run_progress.json"
+            ),
+        )
+
+    def test_init_creates_progress_file(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary:
+            temporary_path = Path(temporary)
+            plan, plan_path = self.create_run_plan(
+                temporary_path
+            )
+            progress_path = (
+                temporary_path
+                / "run_progress.json"
+            )
+            arguments = self.parse_arguments(
+                plan_path,
+                progress_path,
+                "init",
+            )
+
+            with redirect_stdout(StringIO()):
+                exit_code = run_cli(
+                    arguments,
+                    now_provider=lambda: CREATED_AT,
+                )
+
+            progress = load_run_progress(
+                progress_path,
+                plan=plan,
+            )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(progress.run_count, 2)
+        self.assertEqual(
+            progress.status_counts["planned"],
+            2,
+        )
+
+    def test_init_resumes_existing_progress(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary:
+            temporary_path = Path(temporary)
+            _, plan_path = self.create_run_plan(
+                temporary_path
+            )
+            progress_path = (
+                temporary_path
+                / "run_progress.json"
+            )
+            arguments = self.parse_arguments(
+                plan_path,
+                progress_path,
+                "init",
+            )
+
+            with redirect_stdout(StringIO()):
+                run_cli(
+                    arguments,
+                    now_provider=lambda: CREATED_AT,
+                )
+
+            captured_output = StringIO()
+
+            with redirect_stdout(captured_output):
+                exit_code = run_cli(
+                    arguments,
+                    now_provider=lambda: (
+                        "2026-08-23T11:00:00Z"
+                    ),
+                )
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn(
+            "Existing run progress loaded",
+            captured_output.getvalue(),
+        )
+
+    def test_status_displays_progress(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary:
+            temporary_path = Path(temporary)
+            _, plan_path = self.create_run_plan(
+                temporary_path
+            )
+            progress_path = (
+                temporary_path
+                / "run_progress.json"
+            )
+
+            init_arguments = self.parse_arguments(
+                plan_path,
+                progress_path,
+                "init",
+            )
+            status_arguments = self.parse_arguments(
+                plan_path,
+                progress_path,
+                "status",
+            )
+
+            with redirect_stdout(StringIO()):
+                run_cli(
+                    init_arguments,
+                    now_provider=lambda: CREATED_AT,
+                )
+
+            captured_output = StringIO()
+
+            with redirect_stdout(captured_output):
+                exit_code = run_cli(
+                    status_arguments
+                )
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn(
+            "Total runs: 2",
+            captured_output.getvalue(),
+        )
+        self.assertIn(
+            "planned: 2",
+            captured_output.getvalue(),
+        )
+
+    def test_start_next_starts_first_run(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary:
+            temporary_path = Path(temporary)
+            plan, plan_path = self.create_run_plan(
+                temporary_path
+            )
+            progress_path = (
+                temporary_path
+                / "run_progress.json"
+            )
+
+            init_arguments = self.parse_arguments(
+                plan_path,
+                progress_path,
+                "init",
+            )
+            start_arguments = self.parse_arguments(
+                plan_path,
+                progress_path,
+                "start-next",
+            )
+
+            with redirect_stdout(StringIO()):
+                run_cli(
+                    init_arguments,
+                    now_provider=lambda: CREATED_AT,
+                )
+                exit_code = run_cli(
+                    start_arguments,
+                    now_provider=lambda: STARTED_AT,
+                )
+
+            progress = load_run_progress(
+                progress_path,
+                plan=plan,
+            )
+            first_run = progress.get_run_state(
+                "experiment-cli-run-0001"
+            )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(
+            first_run.status,
+            RunStatus.RUNNING,
+        )
+        self.assertEqual(
+            first_run.attempt_count,
+            1,
+        )
+
+    def test_start_next_rejects_second_running_run(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary:
+            temporary_path = Path(temporary)
+            _, plan_path = self.create_run_plan(
+                temporary_path
+            )
+            progress_path = (
+                temporary_path
+                / "run_progress.json"
+            )
+
+            init_arguments = self.parse_arguments(
+                plan_path,
+                progress_path,
+                "init",
+            )
+            start_arguments = self.parse_arguments(
+                plan_path,
+                progress_path,
+                "start-next",
+            )
+
+            with redirect_stdout(StringIO()):
+                run_cli(
+                    init_arguments,
+                    now_provider=lambda: CREATED_AT,
+                )
+                run_cli(
+                    start_arguments,
+                    now_provider=lambda: STARTED_AT,
+                )
+
+            with self.assertRaisesRegex(
+                ControlledIlluminationRunStateError,
+                "already running",
+            ):
+                with redirect_stdout(StringIO()):
+                    run_cli(
+                        start_arguments,
+                        now_provider=lambda: (
+                            "2026-08-23T10:01:00Z"
+                        ),
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This pull request adds resumable execution tracking for controlled-illumination experiments.

It enables experiment runs to be initialized, started, completed, failed, skipped and replanned while preserving progress in an atomically written and validated state file.

## Changes

* Add validated run states and state-transition rules.
* Add experiment-level progress tracking.
* Bind progress files to run-plan manifests using SHA-256.
* Persist and load progress files atomically.
* Support safe resumption of interrupted experiments.
* Prevent more than one run from being active simultaneously.
* Validate run and progress timestamp chronology.
* Add run-plan manifest loading and validation.
* Add CLI commands:

  * `init`
  * `status`
  * `start-next`
  * `complete`
  * `fail`
  * `skip`
  * `replan`
* Record failure and skip reasons.
* Preserve attempt counts when failed or skipped runs are replanned.
* Document the complete run-tracking workflow.
* Add unit and CLI integration tests.

## Validation

* All controlled-illumination experiment tests pass.
* Invalid state transitions are rejected.
* Progress files with mismatched run-plan hashes are rejected.
* Multiple simultaneous running states are rejected.
* Completion timestamps earlier than start timestamps are rejected.
* Progress update timestamps earlier than creation timestamps are rejected.
* Python compilation and Git conflict-marker checks pass.

## Notes

Generated `run_progress.json` files are experiment artifacts and must not be committed to Git.

Closes #32