### PR TITLE
feat: add controlled-illumination execution orchestrator

### DIFF
--- a/benchmarks/experiments/README.md
+++ b/benchmarks/experiments/README.md
@@ -504,3 +504,29 @@ status
 ```
 
 Generated `run_progress.json` files are experiment artifacts and must not be committed to Git.
+
+## Controlled-illumination execution orchestrator
+
+The execution orchestrator connects a generated run-plan manifest to
+the architecture-specific experiment runners.
+
+Each invocation:
+
+1. Loads and validates `run_plan.json`.
+2. Loads or creates `run_progress.json`.
+3. Selects the next run with `planned` status.
+4. Atomically marks the selected run as `running`.
+5. Executes the command configured for its architecture.
+6. Atomically records the run as `completed` or `failed`.
+
+Only one planned run is executed per invocation. Repeated invocations
+continue according to the manifest's `execution_order`.
+
+### Runner configuration
+
+The committed example configuration is:
+
+```text
+benchmarks/experiments/config/controlled_illumination_runner_config.example.json
+```
+

--- a/benchmarks/experiments/config/controlled_illumination_runner_config.example.json
+++ b/benchmarks/experiments/config/controlled_illumination_runner_config.example.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "runners": {
+    "pure_python": {
+      "arguments": [
+        "path/to/pure-python-interpreter",
+        "path/to/pure-python-controlled-runner.py"
+      ],
+      "working_directory": ".",
+      "environment": {},
+      "timeout_seconds": 3600
+    },
+    "hybrid": {
+      "arguments": [
+        "path/to/hybrid-python-interpreter",
+        "path/to/hybrid-controlled-runner.py"
+      ],
+      "working_directory": ".",
+      "environment": {},
+      "timeout_seconds": 3600
+    },
+    "pure_cpp": {
+      "arguments": [
+        "path/to/VisionLabCppControlledIllumination"
+      ],
+      "working_directory": ".",
+      "environment": {},
+      "timeout_seconds": 3600
+    }
+  }
+}

--- a/benchmarks/experiments/controlled_illumination_executor.py
+++ b/benchmarks/experiments/controlled_illumination_executor.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import TypeAlias
+
+from benchmarks.experiments.controlled_illumination_run_planner import (
+    PlannedRun,
+)
+
+
+SUPPORTED_EXECUTION_ARCHITECTURES = frozenset(
+    {
+        "pure_python",
+        "hybrid",
+        "pure_cpp",
+    }
+)
+
+
+class ControlledIlluminationExecutionError(
+    RuntimeError
+):
+    """Raised when an experiment run cannot be executed."""
+
+
+@dataclass(frozen=True)
+class RunnerExecutionResult:
+    exit_code: int
+    standard_output: str = ""
+    standard_error: str = ""
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.exit_code, bool)
+            or not isinstance(self.exit_code, int)
+        ):
+            raise ControlledIlluminationExecutionError(
+                "exit_code must be an integer."
+            )
+
+        if not isinstance(self.standard_output, str):
+            raise ControlledIlluminationExecutionError(
+                "standard_output must be a string."
+            )
+
+        if not isinstance(self.standard_error, str):
+            raise ControlledIlluminationExecutionError(
+                "standard_error must be a string."
+            )
+
+    @property
+    def succeeded(self) -> bool:
+        return self.exit_code == 0
+
+
+ArchitectureRunner: TypeAlias = Callable[
+    [PlannedRun],
+    RunnerExecutionResult,
+]
+
+
+class ArchitectureRunnerRegistry:
+    def __init__(
+        self,
+        runners: Mapping[
+            str,
+            ArchitectureRunner,
+        ],
+    ) -> None:
+        if not isinstance(runners, Mapping):
+            raise ControlledIlluminationExecutionError(
+                "runners must be a mapping."
+            )
+
+        architecture_names = set(runners)
+
+        missing_architectures = (
+            SUPPORTED_EXECUTION_ARCHITECTURES
+            - architecture_names
+        )
+        unexpected_architectures = (
+            architecture_names
+            - SUPPORTED_EXECUTION_ARCHITECTURES
+        )
+
+        if missing_architectures:
+            raise ControlledIlluminationExecutionError(
+                "Missing architecture runners: "
+                f"{sorted(missing_architectures)}"
+            )
+
+        if unexpected_architectures:
+            raise ControlledIlluminationExecutionError(
+                "Unexpected architecture runners: "
+                f"{sorted(unexpected_architectures)}"
+            )
+
+        for architecture, runner in runners.items():
+            if not callable(runner):
+                raise ControlledIlluminationExecutionError(
+                    "Architecture runner must be callable: "
+                    f"{architecture}"
+                )
+
+        self._runners: Mapping[
+            str,
+            ArchitectureRunner,
+        ] = MappingProxyType(
+            dict(runners)
+        )
+
+    def get_runner(
+        self,
+        architecture: str,
+    ) -> ArchitectureRunner:
+        if (
+            not isinstance(architecture, str)
+            or not architecture.strip()
+        ):
+            raise ControlledIlluminationExecutionError(
+                "architecture must be a non-empty string."
+            )
+
+        try:
+            return self._runners[architecture]
+        except KeyError as error:
+            raise ControlledIlluminationExecutionError(
+                "Unsupported execution architecture: "
+                f"{architecture}"
+            ) from error

--- a/benchmarks/experiments/controlled_illumination_executor.py
+++ b/benchmarks/experiments/controlled_illumination_executor.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import subprocess
 from types import MappingProxyType
 from typing import TypeAlias
-from dataclasses import replace
 
 from benchmarks.experiments.controlled_illumination_run_planner import (
     ControlledIlluminationRunPlan,

--- a/benchmarks/experiments/controlled_illumination_executor.py
+++ b/benchmarks/experiments/controlled_illumination_executor.py
@@ -351,6 +351,10 @@ def execute_next_planned_run(
     if planned_run is None:
         return None
 
+    runner = runner_registry.get_runner(
+        planned_run.architecture
+    )
+
     running_progress = transition_progress_run(
         progress,
         planned_run.run_id,
@@ -360,10 +364,6 @@ def execute_next_planned_run(
 
     persist_progress(
         running_progress
-    )
-
-    runner = runner_registry.get_runner(
-        planned_run.architecture
     )
 
     try:

--- a/benchmarks/experiments/controlled_illumination_executor.py
+++ b/benchmarks/experiments/controlled_illumination_executor.py
@@ -370,6 +370,25 @@ def execute_next_planned_run(
         execution_result = runner(
             planned_run
         )
+    except KeyboardInterrupt:
+        interrupted_progress = (
+            transition_progress_run(
+                running_progress,
+                planned_run.run_id,
+                RunStatus.FAILED,
+                timestamp_provider(),
+                reason=(
+                    "Architecture runner was "
+                    "interrupted by the user."
+                ),
+            )
+        )
+
+        persist_progress(
+            interrupted_progress
+        )
+
+        raise
     except Exception as error:
         failure_reason = (
             str(error).strip()

--- a/benchmarks/experiments/controlled_illumination_executor.py
+++ b/benchmarks/experiments/controlled_illumination_executor.py
@@ -13,11 +13,14 @@ from dataclasses import replace
 from benchmarks.experiments.controlled_illumination_run_planner import (
     ControlledIlluminationRunPlan,
     PlannedRun,
+    load_run_plan_manifest,
 )
 
 from benchmarks.experiments.controlled_illumination_run_state import (
     ControlledIlluminationProgress,
     RunStatus,
+    load_or_initialize_run_progress,
+    save_run_progress_atomic,
     transition_progress_run,
     validate_progress_matches_plan,
 )
@@ -438,6 +441,51 @@ def execute_next_planned_run(
         planned_run=planned_run,
         execution_result=execution_result,
         progress=final_progress,
+    )
+
+def execute_next_planned_run_from_files(
+    plan_path: str | Path,
+    progress_path: str | Path,
+    runner_registry: ArchitectureRunnerRegistry,
+    *,
+    timestamp_provider: TimestampProvider,
+) -> OrchestratedRunOutcome | None:
+    if not callable(timestamp_provider):
+        raise ControlledIlluminationExecutionError(
+            "timestamp_provider must be callable."
+        )
+
+    resolved_plan_path = Path(
+        plan_path
+    ).resolve()
+    resolved_progress_path = Path(
+        progress_path
+    ).resolve()
+
+    plan = load_run_plan_manifest(
+        resolved_plan_path
+    )
+
+    progress = load_or_initialize_run_progress(
+        plan,
+        resolved_progress_path,
+        created_at_utc=timestamp_provider(),
+    )
+
+    def persist_progress(
+        updated_progress: ControlledIlluminationProgress,
+    ) -> object:
+        return save_run_progress_atomic(
+            updated_progress,
+            resolved_progress_path,
+        )
+
+    return execute_next_planned_run(
+        plan,
+        progress,
+        runner_registry,
+        timestamp_provider=timestamp_provider,
+        persist_progress=persist_progress,
     )
 
 class SubprocessArchitectureRunner:

--- a/benchmarks/experiments/controlled_illumination_executor.py
+++ b/benchmarks/experiments/controlled_illumination_executor.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+import math
+import os
+from pathlib import Path
+import subprocess
 from types import MappingProxyType
 from typing import TypeAlias
 
@@ -55,11 +59,100 @@ class RunnerExecutionResult:
         return self.exit_code == 0
 
 
+@dataclass(frozen=True)
+class RunnerCommand:
+    arguments: tuple[str, ...]
+    working_directory: Path
+    environment: Mapping[str, str] = field(
+        default_factory=dict
+    )
+    timeout_seconds: float | None = None
+
+    def __post_init__(self) -> None:
+        if (
+            not isinstance(self.arguments, tuple)
+            or not self.arguments
+        ):
+            raise ControlledIlluminationExecutionError(
+                "arguments must be a non-empty tuple."
+            )
+
+        if any(
+            not isinstance(argument, str)
+            or not argument.strip()
+            for argument in self.arguments
+        ):
+            raise ControlledIlluminationExecutionError(
+                "Every command argument must be "
+                "a non-empty string."
+            )
+
+        if not isinstance(
+            self.working_directory,
+            Path,
+        ):
+            raise ControlledIlluminationExecutionError(
+                "working_directory must be a Path."
+            )
+
+        if not isinstance(self.environment, Mapping):
+            raise ControlledIlluminationExecutionError(
+                "environment must be a mapping."
+            )
+
+        for name, value in self.environment.items():
+            if (
+                not isinstance(name, str)
+                or not name.strip()
+                or not isinstance(value, str)
+            ):
+                raise ControlledIlluminationExecutionError(
+                    "Environment variables must use "
+                    "non-empty string names and "
+                    "string values."
+                )
+
+        object.__setattr__(
+            self,
+            "environment",
+            MappingProxyType(
+                dict(self.environment)
+            ),
+        )
+
+        if self.timeout_seconds is not None:
+            if (
+                isinstance(self.timeout_seconds, bool)
+                or not isinstance(
+                    self.timeout_seconds,
+                    (int, float),
+                )
+                or not math.isfinite(
+                    self.timeout_seconds
+                )
+                or self.timeout_seconds <= 0.0
+            ):
+                raise ControlledIlluminationExecutionError(
+                    "timeout_seconds must be positive "
+                    "and finite."
+                )
+
+            object.__setattr__(
+                self,
+                "timeout_seconds",
+                float(self.timeout_seconds),
+            )
+
+
+RunnerCommandBuilder: TypeAlias = Callable[
+    [PlannedRun],
+    RunnerCommand,
+]
+
 ArchitectureRunner: TypeAlias = Callable[
     [PlannedRun],
     RunnerExecutionResult,
 ]
-
 
 class ArchitectureRunnerRegistry:
     def __init__(
@@ -130,3 +223,76 @@ class ArchitectureRunnerRegistry:
                 "Unsupported execution architecture: "
                 f"{architecture}"
             ) from error
+
+class SubprocessArchitectureRunner:
+    def __init__(
+        self,
+        command_builder: RunnerCommandBuilder,
+    ) -> None:
+        if not callable(command_builder):
+            raise ControlledIlluminationExecutionError(
+                "command_builder must be callable."
+            )
+
+        self._command_builder = command_builder
+
+    def __call__(
+        self,
+        planned_run: PlannedRun,
+    ) -> RunnerExecutionResult:
+        if not isinstance(planned_run, PlannedRun):
+            raise ControlledIlluminationExecutionError(
+                "planned_run must be PlannedRun."
+            )
+
+        runner_command = self._command_builder(
+            planned_run
+        )
+
+        if not isinstance(
+            runner_command,
+            RunnerCommand,
+        ):
+            raise ControlledIlluminationExecutionError(
+                "command_builder must return "
+                "RunnerCommand."
+            )
+
+        execution_environment = os.environ.copy()
+        execution_environment.update(
+            runner_command.environment
+        )
+
+        try:
+            completed_process = subprocess.run(
+                runner_command.arguments,
+                cwd=runner_command.working_directory,
+                env=execution_environment,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=(
+                    runner_command.timeout_seconds
+                ),
+            )
+        except subprocess.TimeoutExpired as error:
+            raise ControlledIlluminationExecutionError(
+                "Architecture runner timed out after "
+                f"{runner_command.timeout_seconds} "
+                "seconds."
+            ) from error
+        except OSError as error:
+            raise ControlledIlluminationExecutionError(
+                "Architecture runner could not be "
+                f"started: {error}"
+            ) from error
+
+        return RunnerExecutionResult(
+            exit_code=completed_process.returncode,
+            standard_output=(
+                completed_process.stdout or ""
+            ),
+            standard_error=(
+                completed_process.stderr or ""
+            ),
+        )

--- a/benchmarks/experiments/controlled_illumination_executor.py
+++ b/benchmarks/experiments/controlled_illumination_executor.py
@@ -8,9 +8,18 @@ from pathlib import Path
 import subprocess
 from types import MappingProxyType
 from typing import TypeAlias
+from dataclasses import replace
 
 from benchmarks.experiments.controlled_illumination_run_planner import (
+    ControlledIlluminationRunPlan,
     PlannedRun,
+)
+
+from benchmarks.experiments.controlled_illumination_run_state import (
+    ControlledIlluminationProgress,
+    RunStatus,
+    transition_progress_run,
+    validate_progress_matches_plan,
 )
 
 
@@ -21,6 +30,16 @@ SUPPORTED_EXECUTION_ARCHITECTURES = frozenset(
         "pure_cpp",
     }
 )
+
+TimestampProvider: TypeAlias = Callable[
+    [],
+    str,
+]
+
+ProgressPersistenceCallback: TypeAlias = Callable[
+    [ControlledIlluminationProgress],
+    object,
+]
 
 
 class ControlledIlluminationExecutionError(
@@ -223,6 +242,203 @@ class ArchitectureRunnerRegistry:
                 "Unsupported execution architecture: "
                 f"{architecture}"
             ) from error
+
+@dataclass(frozen=True)
+class OrchestratedRunOutcome:
+    planned_run: PlannedRun
+    execution_result: RunnerExecutionResult
+    progress: ControlledIlluminationProgress
+
+    @property
+    def succeeded(self) -> bool:
+        return self.execution_result.succeeded
+
+
+def select_next_planned_run(
+    plan: ControlledIlluminationRunPlan,
+    progress: ControlledIlluminationProgress,
+) -> PlannedRun | None:
+    if not isinstance(
+        plan,
+        ControlledIlluminationRunPlan,
+    ):
+        raise ControlledIlluminationExecutionError(
+            "plan must be ControlledIlluminationRunPlan."
+        )
+
+    if not isinstance(
+        progress,
+        ControlledIlluminationProgress,
+    ):
+        raise ControlledIlluminationExecutionError(
+            "progress must be "
+            "ControlledIlluminationProgress."
+        )
+
+    validate_progress_matches_plan(
+        progress,
+        plan,
+    )
+
+    for planned_run in plan.runs:
+        run_state = progress.get_run_state(
+            planned_run.run_id
+        )
+
+        if run_state.status == RunStatus.PLANNED:
+            return planned_run
+
+    return None
+
+
+def build_runner_failure_reason(
+    execution_result: RunnerExecutionResult,
+) -> str:
+    reason = (
+        execution_result.standard_error.strip()
+        or execution_result.standard_output.strip()
+    )
+
+    exit_description = (
+        "Architecture runner exited with code "
+        f"{execution_result.exit_code}."
+    )
+
+    if not reason:
+        return exit_description
+
+    return (
+        f"{exit_description} "
+        f"Runner output: {reason}"
+    )
+
+
+def execute_next_planned_run(
+    plan: ControlledIlluminationRunPlan,
+    progress: ControlledIlluminationProgress,
+    runner_registry: ArchitectureRunnerRegistry,
+    *,
+    timestamp_provider: TimestampProvider,
+    persist_progress: ProgressPersistenceCallback,
+) -> OrchestratedRunOutcome | None:
+    if not isinstance(
+        runner_registry,
+        ArchitectureRunnerRegistry,
+    ):
+        raise ControlledIlluminationExecutionError(
+            "runner_registry must be "
+            "ArchitectureRunnerRegistry."
+        )
+
+    if not callable(timestamp_provider):
+        raise ControlledIlluminationExecutionError(
+            "timestamp_provider must be callable."
+        )
+
+    if not callable(persist_progress):
+        raise ControlledIlluminationExecutionError(
+            "persist_progress must be callable."
+        )
+
+    planned_run = select_next_planned_run(
+        plan,
+        progress,
+    )
+
+    if planned_run is None:
+        return None
+
+    running_progress = transition_progress_run(
+        progress,
+        planned_run.run_id,
+        RunStatus.RUNNING,
+        timestamp_provider(),
+    )
+
+    persist_progress(
+        running_progress
+    )
+
+    runner = runner_registry.get_runner(
+        planned_run.architecture
+    )
+
+    try:
+        execution_result = runner(
+            planned_run
+        )
+    except Exception as error:
+        failure_reason = (
+            str(error).strip()
+            or error.__class__.__name__
+        )
+
+        failed_progress = transition_progress_run(
+            running_progress,
+            planned_run.run_id,
+            RunStatus.FAILED,
+            timestamp_provider(),
+            reason=failure_reason,
+        )
+
+        persist_progress(
+            failed_progress
+        )
+
+        raise
+
+    if not isinstance(
+        execution_result,
+        RunnerExecutionResult,
+    ):
+        invalid_result_error = (
+            ControlledIlluminationExecutionError(
+                "Architecture runner must return "
+                "RunnerExecutionResult."
+            )
+        )
+
+        failed_progress = transition_progress_run(
+            running_progress,
+            planned_run.run_id,
+            RunStatus.FAILED,
+            timestamp_provider(),
+            reason=str(invalid_result_error),
+        )
+
+        persist_progress(
+            failed_progress
+        )
+
+        raise invalid_result_error
+
+    if execution_result.succeeded:
+        final_progress = transition_progress_run(
+            running_progress,
+            planned_run.run_id,
+            RunStatus.COMPLETED,
+            timestamp_provider(),
+        )
+    else:
+        final_progress = transition_progress_run(
+            running_progress,
+            planned_run.run_id,
+            RunStatus.FAILED,
+            timestamp_provider(),
+            reason=build_runner_failure_reason(
+                execution_result
+            ),
+        )
+
+    persist_progress(
+        final_progress
+    )
+
+    return OrchestratedRunOutcome(
+        planned_run=planned_run,
+        execution_result=execution_result,
+        progress=final_progress,
+    )
 
 class SubprocessArchitectureRunner:
     def __init__(

--- a/benchmarks/experiments/execute_controlled_illumination_run.py
+++ b/benchmarks/experiments/execute_controlled_illumination_run.py
@@ -1,0 +1,479 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable, Mapping, Sequence
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+from benchmarks.experiments.controlled_illumination_executor import (
+    SUPPORTED_EXECUTION_ARCHITECTURES,
+    ArchitectureRunnerRegistry,
+    ControlledIlluminationExecutionError,
+    RunnerCommand,
+    SubprocessArchitectureRunner,
+    execute_next_planned_run_from_files,
+)
+from benchmarks.experiments.controlled_illumination_run_planner import (
+    PlannedRun,
+)
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+RUNNER_CONFIG_SCHEMA_VERSION = 1
+
+
+def current_utc_timestamp() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .isoformat(timespec="microseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def determine_progress_path(
+    plan_path: str | Path,
+    progress_path: str | Path | None,
+) -> Path:
+    if progress_path is not None:
+        return Path(progress_path).resolve()
+
+    return (
+        Path(plan_path).resolve().parent
+        / "run_progress.json"
+    )
+
+
+def require_mapping(
+    value: Any,
+    field_name: str,
+) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ControlledIlluminationExecutionError(
+            f"{field_name} must be an object."
+        )
+
+    return value
+
+
+def require_command_arguments(
+    value: Any,
+    field_name: str,
+) -> tuple[str, ...]:
+    if (
+        not isinstance(value, list)
+        or not value
+        or any(
+            not isinstance(argument, str)
+            or not argument.strip()
+            for argument in value
+        )
+    ):
+        raise ControlledIlluminationExecutionError(
+            f"{field_name} must be a non-empty "
+            "array of non-empty strings."
+        )
+
+    return tuple(value)
+
+
+def require_environment(
+    value: Any,
+    field_name: str,
+) -> dict[str, str]:
+    if value is None:
+        return {}
+
+    environment = require_mapping(
+        value,
+        field_name,
+    )
+
+    for name, environment_value in environment.items():
+        if (
+            not isinstance(name, str)
+            or not name.strip()
+            or not isinstance(environment_value, str)
+        ):
+            raise ControlledIlluminationExecutionError(
+                f"{field_name} must use non-empty "
+                "string names and string values."
+            )
+
+    return dict(environment)
+
+
+def resolve_working_directory(
+    value: Any,
+    field_name: str,
+) -> Path:
+    if value is None:
+        return PROJECT_ROOT
+
+    if not isinstance(value, str) or not value.strip():
+        raise ControlledIlluminationExecutionError(
+            f"{field_name} must be a non-empty string."
+        )
+
+    working_directory = Path(value)
+
+    if not working_directory.is_absolute():
+        working_directory = (
+            PROJECT_ROOT / working_directory
+        )
+
+    return working_directory.resolve()
+
+
+def require_optional_timeout(
+    value: Any,
+    field_name: str,
+) -> float | None:
+    if value is None:
+        return None
+
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or value <= 0
+    ):
+        raise ControlledIlluminationExecutionError(
+            f"{field_name} must be a positive number."
+        )
+
+    return float(value)
+
+
+def serialize_optional_value(
+    value: str | int | float | None,
+) -> str:
+    if value is None:
+        return ""
+
+    return str(value)
+
+
+def build_planned_run_environment(
+    planned_run: PlannedRun,
+) -> dict[str, str]:
+    if not isinstance(planned_run, PlannedRun):
+        raise ControlledIlluminationExecutionError(
+            "planned_run must be PlannedRun."
+        )
+
+    return {
+        "VISIONLAB_EXPERIMENT_ID": (
+            planned_run.experiment_id
+        ),
+        "VISIONLAB_RUN_ID": planned_run.run_id,
+        "VISIONLAB_EXECUTION_ORDER": str(
+            planned_run.execution_order
+        ),
+        "VISIONLAB_PHASE": planned_run.phase,
+        "VISIONLAB_PLATFORM": planned_run.platform,
+        "VISIONLAB_ARCHITECTURE": (
+            planned_run.architecture
+        ),
+        "VISIONLAB_ALGORITHM": planned_run.algorithm,
+        "VISIONLAB_RESOLUTION_WIDTH": str(
+            planned_run.resolution.width
+        ),
+        "VISIONLAB_RESOLUTION_HEIGHT": str(
+            planned_run.resolution.height
+        ),
+        "VISIONLAB_TRIAL_NUMBER": str(
+            planned_run.trial_number
+        ),
+        "VISIONLAB_INCIDENCE_ANGLE_DEGREES": str(
+            planned_run.incidence_angle_degrees
+        ),
+        "VISIONLAB_TARGET_ILLUMINANCE_LUX": (
+            serialize_optional_value(
+                planned_run.target_illuminance_lux
+            )
+        ),
+        "VISIONLAB_SOURCE_OUTPUT_SETTING": (
+            serialize_optional_value(
+                planned_run.source_output_setting
+            )
+        ),
+        "VISIONLAB_TARGET_FPS": str(
+            planned_run.target_fps
+        ),
+        "VISIONLAB_FRAME_DEADLINE_MS": str(
+            planned_run.frame_deadline_ms
+        ),
+    }
+
+
+def load_runner_registry(
+    config_path: str | Path,
+) -> ArchitectureRunnerRegistry:
+    resolved_config_path = Path(
+        config_path
+    ).resolve()
+
+    try:
+        with resolved_config_path.open(
+            "r",
+            encoding="utf-8",
+        ) as config_file:
+            config_value = json.load(config_file)
+    except (OSError, json.JSONDecodeError) as error:
+        raise ControlledIlluminationExecutionError(
+            "Runner configuration could not be "
+            f"loaded: {error}"
+        ) from error
+
+    config = require_mapping(
+        config_value,
+        "runner configuration",
+    )
+
+    if config.get("schema_version") != (
+        RUNNER_CONFIG_SCHEMA_VERSION
+    ):
+        raise ControlledIlluminationExecutionError(
+            "runner configuration schema_version "
+            "must be 1."
+        )
+
+    runner_values = require_mapping(
+        config.get("runners"),
+        "runners",
+    )
+
+    configured_architectures = set(
+        runner_values
+    )
+
+    if configured_architectures != (
+        SUPPORTED_EXECUTION_ARCHITECTURES
+    ):
+        missing = sorted(
+            SUPPORTED_EXECUTION_ARCHITECTURES
+            - configured_architectures
+        )
+        unexpected = sorted(
+            configured_architectures
+            - SUPPORTED_EXECUTION_ARCHITECTURES
+        )
+
+        raise ControlledIlluminationExecutionError(
+            "Runner configuration architectures "
+            f"do not match. Missing: {missing}; "
+            f"unexpected: {unexpected}."
+        )
+
+    architecture_runners = {}
+
+    for architecture in sorted(
+        SUPPORTED_EXECUTION_ARCHITECTURES
+    ):
+        runner_value = require_mapping(
+            runner_values[architecture],
+            f"runners.{architecture}",
+        )
+
+        allowed_fields = {
+            "arguments",
+            "working_directory",
+            "environment",
+            "timeout_seconds",
+        }
+        unexpected_fields = (
+            set(runner_value) - allowed_fields
+        )
+
+        if unexpected_fields:
+            raise ControlledIlluminationExecutionError(
+                f"Unexpected fields in runners."
+                f"{architecture}: "
+                f"{sorted(unexpected_fields)}"
+            )
+
+        arguments = require_command_arguments(
+            runner_value.get("arguments"),
+            f"runners.{architecture}.arguments",
+        )
+        working_directory = (
+            resolve_working_directory(
+                runner_value.get(
+                    "working_directory"
+                ),
+                (
+                    f"runners.{architecture}."
+                    "working_directory"
+                ),
+            )
+        )
+        base_environment = require_environment(
+            runner_value.get("environment"),
+            f"runners.{architecture}.environment",
+        )
+        timeout_seconds = require_optional_timeout(
+            runner_value.get("timeout_seconds"),
+            (
+                f"runners.{architecture}."
+                "timeout_seconds"
+            ),
+        )
+
+        def command_builder(
+            planned_run: PlannedRun,
+            *,
+            command_arguments: tuple[str, ...] = (
+                arguments
+            ),
+            command_working_directory: Path = (
+                working_directory
+            ),
+            command_environment: Mapping[str, str] = (
+                base_environment
+            ),
+            command_timeout_seconds: float | None = (
+                timeout_seconds
+            ),
+        ) -> RunnerCommand:
+            execution_environment = dict(
+                command_environment
+            )
+            execution_environment.update(
+                build_planned_run_environment(
+                    planned_run
+                )
+            )
+
+            return RunnerCommand(
+                arguments=command_arguments,
+                working_directory=(
+                    command_working_directory
+                ),
+                environment=execution_environment,
+                timeout_seconds=(
+                    command_timeout_seconds
+                ),
+            )
+
+        architecture_runners[architecture] = (
+            SubprocessArchitectureRunner(
+                command_builder
+            )
+        )
+
+    return ArchitectureRunnerRegistry(
+        architecture_runners
+    )
+
+
+def create_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Execute the next planned controlled-"
+            "illumination experiment run."
+        )
+    )
+    parser.add_argument(
+        "--plan",
+        required=True,
+        help="Path to run_plan.json.",
+    )
+    parser.add_argument(
+        "--progress",
+        help=(
+            "Path to run_progress.json. Defaults "
+            "to the run-plan directory."
+        ),
+    )
+    parser.add_argument(
+        "--runner-config",
+        required=True,
+        help=(
+            "Path to the architecture runner "
+            "configuration JSON file."
+        ),
+    )
+    return parser
+
+
+def run_cli(
+    arguments: argparse.Namespace,
+    *,
+    timestamp_provider: Callable[[], str] = (
+        current_utc_timestamp
+    ),
+) -> int:
+    plan_path = Path(arguments.plan).resolve()
+    progress_path = determine_progress_path(
+        plan_path,
+        arguments.progress,
+    )
+    runner_registry = load_runner_registry(
+        arguments.runner_config
+    )
+
+    outcome = execute_next_planned_run_from_files(
+        plan_path,
+        progress_path,
+        runner_registry,
+        timestamp_provider=timestamp_provider,
+    )
+
+    if outcome is None:
+        print("No planned experiment runs remain.")
+        return 0
+
+    if outcome.succeeded:
+        print(
+            "Controlled-illumination run completed: "
+            f"{outcome.planned_run.run_id}"
+        )
+        return 0
+
+    print(
+        "Controlled-illumination run failed: "
+        f"{outcome.planned_run.run_id}",
+        file=sys.stderr,
+    )
+
+    if outcome.execution_result.standard_error:
+        print(
+            outcome.execution_result.standard_error,
+            file=sys.stderr,
+        )
+
+    return 1
+
+
+def main(
+    argv: Sequence[str] | None = None,
+) -> int:
+    parser = create_argument_parser()
+    arguments = parser.parse_args(argv)
+
+    try:
+        return run_cli(arguments)
+    except KeyboardInterrupt:
+        print(
+            "Controlled-illumination execution "
+            "interrupted.",
+            file=sys.stderr,
+        )
+        return 130
+    except (
+        ControlledIlluminationExecutionError,
+        OSError,
+        ValueError,
+    ) as error:
+        print(
+            f"Controlled-illumination execution "
+            f"failed: {error}",
+            file=sys.stderr,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/experiments/tests/test_controlled_illumination_executor.py
+++ b/benchmarks/experiments/tests/test_controlled_illumination_executor.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import subprocess
 import unittest
 from unittest.mock import patch
+from tempfile import TemporaryDirectory
 
 from benchmarks.experiments.controlled_illumination_executor import (
     ArchitectureRunnerRegistry,
@@ -14,6 +15,7 @@ from benchmarks.experiments.controlled_illumination_executor import (
     SubprocessArchitectureRunner,
     execute_next_planned_run,
     select_next_planned_run,
+    execute_next_planned_run_from_files,
 )
 from benchmarks.experiments.controlled_illumination_metadata import (
     ResolutionMetadata,
@@ -21,11 +23,13 @@ from benchmarks.experiments.controlled_illumination_metadata import (
 from benchmarks.experiments.controlled_illumination_run_planner import (
     ControlledIlluminationRunPlan,
     PlannedRun,
+    write_run_plan_manifests_atomic,
 )
 from benchmarks.experiments.controlled_illumination_run_state import (
     RunStatus,
     initialize_run_progress,
     transition_progress_run,
+    load_run_progress,
 )
 
 
@@ -582,6 +586,162 @@ class ControlledIlluminationExecutorTests(
             "runner exploded",
         )
 
+    def test_file_execution_creates_progress(
+            self,
+    ) -> None:
+        with TemporaryDirectory() as temporary:
+            temporary_path = Path(temporary)
+            plan = self.build_run_plan()
+
+            plan_path, _ = (
+                write_run_plan_manifests_atomic(
+                    plan,
+                    temporary_path,
+                )
+            )
+            progress_path = (
+                    temporary_path
+                    / "run_progress.json"
+            )
+            timestamps = iter(
+                (
+                    "2026-08-24T09:01:00Z",
+                    "2026-08-24T09:02:00Z",
+                    "2026-08-24T09:03:00Z",
+                )
+            )
+
+            outcome = (
+                execute_next_planned_run_from_files(
+                    plan_path,
+                    progress_path,
+                    ArchitectureRunnerRegistry(
+                        self.build_runners()
+                    ),
+                    timestamp_provider=lambda: next(
+                        timestamps
+                    ),
+                )
+            )
+
+            persisted_progress = load_run_progress(
+                progress_path,
+                plan=plan,
+            )
+
+        self.assertIsNotNone(outcome)
+        self.assertTrue(outcome.succeeded)
+        self.assertEqual(
+            persisted_progress.get_run_state(
+                plan.runs[0].run_id
+            ).status,
+            RunStatus.COMPLETED,
+        )
+        self.assertEqual(
+            persisted_progress.get_run_state(
+                plan.runs[1].run_id
+            ).status,
+            RunStatus.PLANNED,
+        )
+
+    def test_file_execution_resumes_existing_progress(
+            self,
+    ) -> None:
+        with TemporaryDirectory() as temporary:
+            temporary_path = Path(temporary)
+            plan = self.build_run_plan()
+
+            plan_path, _ = (
+                write_run_plan_manifests_atomic(
+                    plan,
+                    temporary_path,
+                )
+            )
+            progress_path = (
+                    temporary_path
+                    / "run_progress.json"
+            )
+            runner_registry = (
+                ArchitectureRunnerRegistry(
+                    self.build_runners()
+                )
+            )
+
+            first_timestamps = iter(
+                (
+                    "2026-08-24T09:01:00Z",
+                    "2026-08-24T09:02:00Z",
+                    "2026-08-24T09:03:00Z",
+                )
+            )
+
+            first_outcome = (
+                execute_next_planned_run_from_files(
+                    plan_path,
+                    progress_path,
+                    runner_registry,
+                    timestamp_provider=lambda: next(
+                        first_timestamps
+                    ),
+                )
+            )
+
+            second_timestamps = iter(
+                (
+                    "2026-08-24T09:04:00Z",
+                    "2026-08-24T09:05:00Z",
+                    "2026-08-24T09:06:00Z",
+                )
+            )
+
+            second_outcome = (
+                execute_next_planned_run_from_files(
+                    plan_path,
+                    progress_path,
+                    runner_registry,
+                    timestamp_provider=lambda: next(
+                        second_timestamps
+                    ),
+                )
+            )
+
+            no_run_outcome = (
+                execute_next_planned_run_from_files(
+                    plan_path,
+                    progress_path,
+                    runner_registry,
+                    timestamp_provider=lambda: (
+                        "2026-08-24T09:07:00Z"
+                    ),
+                )
+            )
+
+            persisted_progress = load_run_progress(
+                progress_path,
+                plan=plan,
+            )
+
+        self.assertIsNotNone(first_outcome)
+        self.assertEqual(
+            first_outcome.planned_run.run_id,
+            plan.runs[0].run_id,
+        )
+
+        self.assertIsNotNone(second_outcome)
+        self.assertEqual(
+            second_outcome.planned_run.run_id,
+            plan.runs[1].run_id,
+        )
+
+        self.assertIsNone(no_run_outcome)
+
+        for planned_run in plan.runs:
+            self.assertEqual(
+                persisted_progress.get_run_state(
+                    planned_run.run_id
+                ).status,
+                RunStatus.COMPLETED,
+            )
 
 if __name__ == "__main__":
     unittest.main()

--- a/benchmarks/experiments/tests/test_controlled_illumination_executor.py
+++ b/benchmarks/experiments/tests/test_controlled_illumination_executor.py
@@ -1,17 +1,50 @@
 from __future__ import annotations
 
+from pathlib import Path
+import subprocess
 import unittest
+from unittest.mock import patch
 
 from benchmarks.experiments.controlled_illumination_executor import (
     ArchitectureRunnerRegistry,
     ControlledIlluminationExecutionError,
+    RunnerCommand,
     RunnerExecutionResult,
+    SubprocessArchitectureRunner,
+)
+from benchmarks.experiments.controlled_illumination_metadata import (
+    ResolutionMetadata,
+)
+from benchmarks.experiments.controlled_illumination_run_planner import (
+    PlannedRun,
 )
 
 
 class ControlledIlluminationExecutorTests(
     unittest.TestCase
 ):
+    @staticmethod
+    def build_planned_run() -> PlannedRun:
+        return PlannedRun(
+            execution_order=1,
+            experiment_id="experiment-executor",
+            run_id="experiment-executor-run-0001",
+            phase="constant_lux",
+            platform="desktop",
+            architecture="pure_python",
+            algorithm="original",
+            resolution=ResolutionMetadata(
+                width=640,
+                height=480,
+            ),
+            trial_number=1,
+            incidence_angle_degrees=0.0,
+            target_illuminance_lux=50.0,
+            source_output_setting=None,
+            target_fps=30.0,
+            frame_deadline_ms=1000.0 / 30.0,
+        )
+
     @staticmethod
     def successful_runner(
         planned_run,
@@ -113,6 +146,153 @@ class ControlledIlluminationExecutorTests(
         ):
             registry.get_runner(
                 "unknown"
+            )
+
+    def test_runner_command_rejects_empty_arguments(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(
+            ControlledIlluminationExecutionError,
+            "arguments",
+        ):
+            RunnerCommand(
+                arguments=(),
+                working_directory=Path("."),
+            )
+
+    def test_subprocess_runner_captures_result(
+        self,
+    ) -> None:
+        command = RunnerCommand(
+            arguments=("python", "runner.py"),
+            working_directory=Path("."),
+            environment={
+                "VISIONLAB_TEST": "enabled",
+            },
+            timeout_seconds=30.0,
+        )
+
+        completed_process = subprocess.CompletedProcess(
+            args=command.arguments,
+            returncode=0,
+            stdout="completed\n",
+            stderr="",
+        )
+
+        with patch(
+            "benchmarks.experiments."
+            "controlled_illumination_executor."
+            "subprocess.run",
+            return_value=completed_process,
+        ) as run_mock:
+            runner = SubprocessArchitectureRunner(
+                lambda planned_run: command
+            )
+
+            result = runner(
+                self.build_planned_run()
+            )
+
+        self.assertTrue(result.succeeded)
+        self.assertEqual(
+            result.standard_output,
+            "completed\n",
+        )
+
+        run_mock.assert_called_once()
+
+        call_arguments = run_mock.call_args
+
+        self.assertEqual(
+            call_arguments.args[0],
+            command.arguments,
+        )
+        self.assertEqual(
+            call_arguments.kwargs["cwd"],
+            Path("."),
+        )
+        self.assertEqual(
+            call_arguments.kwargs["env"][
+                "VISIONLAB_TEST"
+            ],
+            "enabled",
+        )
+        self.assertEqual(
+            call_arguments.kwargs["timeout"],
+            30.0,
+        )
+
+    def test_subprocess_runner_rejects_timeout(
+        self,
+    ) -> None:
+        command = RunnerCommand(
+            arguments=("python", "runner.py"),
+            working_directory=Path("."),
+            timeout_seconds=1.0,
+        )
+
+        with patch(
+            "benchmarks.experiments."
+            "controlled_illumination_executor."
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(
+                cmd=command.arguments,
+                timeout=1.0,
+            ),
+        ):
+            runner = SubprocessArchitectureRunner(
+                lambda planned_run: command
+            )
+
+            with self.assertRaisesRegex(
+                ControlledIlluminationExecutionError,
+                "timed out",
+            ):
+                runner(
+                    self.build_planned_run()
+                )
+
+    def test_subprocess_runner_rejects_start_failure(
+        self,
+    ) -> None:
+        command = RunnerCommand(
+            arguments=("missing-runner",),
+            working_directory=Path("."),
+        )
+
+        with patch(
+            "benchmarks.experiments."
+            "controlled_illumination_executor."
+            "subprocess.run",
+            side_effect=FileNotFoundError(
+                "runner not found"
+            ),
+        ):
+            runner = SubprocessArchitectureRunner(
+                lambda planned_run: command
+            )
+
+            with self.assertRaisesRegex(
+                ControlledIlluminationExecutionError,
+                "could not be started",
+            ):
+                runner(
+                    self.build_planned_run()
+                )
+
+    def test_subprocess_runner_rejects_invalid_command(
+        self,
+    ) -> None:
+        runner = SubprocessArchitectureRunner(
+            lambda planned_run: "invalid"  # type: ignore[return-value]
+        )
+
+        with self.assertRaisesRegex(
+            ControlledIlluminationExecutionError,
+            "must return RunnerCommand",
+        ):
+            runner(
+                self.build_planned_run()
             )
 
 

--- a/benchmarks/experiments/tests/test_controlled_illumination_executor.py
+++ b/benchmarks/experiments/tests/test_controlled_illumination_executor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 import subprocess
 import unittest
@@ -11,12 +12,20 @@ from benchmarks.experiments.controlled_illumination_executor import (
     RunnerCommand,
     RunnerExecutionResult,
     SubprocessArchitectureRunner,
+    execute_next_planned_run,
+    select_next_planned_run,
 )
 from benchmarks.experiments.controlled_illumination_metadata import (
     ResolutionMetadata,
 )
 from benchmarks.experiments.controlled_illumination_run_planner import (
+    ControlledIlluminationRunPlan,
     PlannedRun,
+)
+from benchmarks.experiments.controlled_illumination_run_state import (
+    RunStatus,
+    initialize_run_progress,
+    transition_progress_run,
 )
 
 
@@ -43,6 +52,32 @@ class ControlledIlluminationExecutorTests(
             source_output_setting=None,
             target_fps=30.0,
             frame_deadline_ms=1000.0 / 30.0,
+        )
+
+    def build_run_plan(
+        self,
+    ) -> ControlledIlluminationRunPlan:
+        first_run = self.build_planned_run()
+
+        second_run = replace(
+            first_run,
+            execution_order=2,
+            run_id="experiment-executor-run-0002",
+            trial_number=2,
+        )
+
+        return ControlledIlluminationRunPlan(
+            schema_version=1,
+            generated_at_utc=(
+                "2026-08-24T09:00:00Z"
+            ),
+            experiment_id="experiment-executor",
+            randomized=False,
+            randomization_seed=20260824,
+            runs=(
+                first_run,
+                second_run,
+            ),
         )
 
     @staticmethod
@@ -294,6 +329,258 @@ class ControlledIlluminationExecutorTests(
             runner(
                 self.build_planned_run()
             )
+
+    def test_selects_first_planned_run(
+        self,
+    ) -> None:
+        plan = self.build_run_plan()
+        progress = initialize_run_progress(
+            plan,
+            created_at_utc="2026-08-24T09:01:00Z",
+        )
+
+        selected_run = select_next_planned_run(
+            plan,
+            progress,
+        )
+
+        self.assertIsNotNone(selected_run)
+        self.assertEqual(
+            selected_run.run_id,
+            "experiment-executor-run-0001",
+        )
+
+    def test_selects_next_run_after_completion(
+        self,
+    ) -> None:
+        plan = self.build_run_plan()
+        progress = initialize_run_progress(
+            plan,
+            created_at_utc="2026-08-24T09:01:00Z",
+        )
+
+        progress = transition_progress_run(
+            progress,
+            plan.runs[0].run_id,
+            RunStatus.RUNNING,
+            "2026-08-24T09:02:00Z",
+        )
+        progress = transition_progress_run(
+            progress,
+            plan.runs[0].run_id,
+            RunStatus.COMPLETED,
+            "2026-08-24T09:03:00Z",
+        )
+
+        selected_run = select_next_planned_run(
+            plan,
+            progress,
+        )
+
+        self.assertIsNotNone(selected_run)
+        self.assertEqual(
+            selected_run.run_id,
+            "experiment-executor-run-0002",
+        )
+
+    def test_returns_none_when_no_runs_remain(
+        self,
+    ) -> None:
+        plan = self.build_run_plan()
+        progress = initialize_run_progress(
+            plan,
+            created_at_utc="2026-08-24T09:01:00Z",
+        )
+        transition_timestamps = (
+            (
+                "2026-08-24T09:02:00Z",
+                "2026-08-24T09:03:00Z",
+            ),
+            (
+                "2026-08-24T09:04:00Z",
+                "2026-08-24T09:05:00Z",
+            ),
+        )
+
+        for planned_run, timestamps in zip(
+            plan.runs,
+            transition_timestamps,
+            strict=True,
+        ):
+            started_at_utc, finished_at_utc = (
+                timestamps
+            )
+            progress = transition_progress_run(
+                progress,
+                planned_run.run_id,
+                RunStatus.RUNNING,
+                started_at_utc,
+            )
+            progress = transition_progress_run(
+                progress,
+                planned_run.run_id,
+                RunStatus.COMPLETED,
+                finished_at_utc,
+            )
+
+        self.assertIsNone(
+            select_next_planned_run(
+                plan,
+                progress,
+            )
+        )
+
+    def test_successful_execution_completes_run(
+        self,
+    ) -> None:
+        plan = self.build_run_plan()
+        progress = initialize_run_progress(
+            plan,
+            created_at_utc="2026-08-24T09:01:00Z",
+        )
+        saved_progress = []
+        timestamps = iter(
+            (
+                "2026-08-24T09:02:00Z",
+                "2026-08-24T09:03:00Z",
+            )
+        )
+
+        outcome = execute_next_planned_run(
+            plan,
+            progress,
+            ArchitectureRunnerRegistry(
+                self.build_runners()
+            ),
+            timestamp_provider=lambda: next(
+                timestamps
+            ),
+            persist_progress=saved_progress.append,
+        )
+
+        self.assertIsNotNone(outcome)
+        self.assertTrue(outcome.succeeded)
+        self.assertEqual(
+            len(saved_progress),
+            2,
+        )
+        self.assertEqual(
+            saved_progress[0].get_run_state(
+                plan.runs[0].run_id
+            ).status,
+            RunStatus.RUNNING,
+        )
+        self.assertEqual(
+            outcome.progress.get_run_state(
+                plan.runs[0].run_id
+            ).status,
+            RunStatus.COMPLETED,
+        )
+
+    def test_failed_result_marks_run_failed(
+        self,
+    ) -> None:
+        plan = self.build_run_plan()
+        progress = initialize_run_progress(
+            plan,
+            created_at_utc="2026-08-24T09:01:00Z",
+        )
+        runners = self.build_runners()
+        runners["pure_python"] = (
+            lambda planned_run: RunnerExecutionResult(
+                exit_code=5,
+                standard_error="runner failed",
+            )
+        )
+        saved_progress = []
+        timestamps = iter(
+            (
+                "2026-08-24T09:02:00Z",
+                "2026-08-24T09:03:00Z",
+            )
+        )
+
+        outcome = execute_next_planned_run(
+            plan,
+            progress,
+            ArchitectureRunnerRegistry(runners),
+            timestamp_provider=lambda: next(
+                timestamps
+            ),
+            persist_progress=saved_progress.append,
+        )
+
+        self.assertIsNotNone(outcome)
+        final_state = outcome.progress.get_run_state(
+            plan.runs[0].run_id
+        )
+
+        self.assertFalse(outcome.succeeded)
+        self.assertEqual(
+            final_state.status,
+            RunStatus.FAILED,
+        )
+        self.assertIn(
+            "runner failed",
+            final_state.failure_reason,
+        )
+        self.assertEqual(
+            len(saved_progress),
+            2,
+        )
+
+    def test_runner_exception_marks_run_failed(
+        self,
+    ) -> None:
+        plan = self.build_run_plan()
+        progress = initialize_run_progress(
+            plan,
+            created_at_utc="2026-08-24T09:01:00Z",
+        )
+
+        def failing_runner(
+            planned_run,
+        ) -> RunnerExecutionResult:
+            raise RuntimeError(
+                "runner exploded"
+            )
+
+        runners = self.build_runners()
+        runners["pure_python"] = failing_runner
+        saved_progress = []
+        timestamps = iter(
+            (
+                "2026-08-24T09:02:00Z",
+                "2026-08-24T09:03:00Z",
+            )
+        )
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "runner exploded",
+        ):
+            execute_next_planned_run(
+                plan,
+                progress,
+                ArchitectureRunnerRegistry(runners),
+                timestamp_provider=lambda: next(
+                    timestamps
+                ),
+                persist_progress=saved_progress.append,
+            )
+
+        failed_state = saved_progress[-1].get_run_state(
+            plan.runs[0].run_id
+        )
+
+        self.assertEqual(
+            failed_state.status,
+            RunStatus.FAILED,
+        )
+        self.assertEqual(
+            failed_state.failure_reason,
+            "runner exploded",
+        )
 
 
 if __name__ == "__main__":

--- a/benchmarks/experiments/tests/test_controlled_illumination_executor.py
+++ b/benchmarks/experiments/tests/test_controlled_illumination_executor.py
@@ -743,5 +743,60 @@ class ControlledIlluminationExecutorTests(
                 RunStatus.COMPLETED,
             )
 
+    def test_runner_interrupt_marks_run_failed(
+            self,
+    ) -> None:
+        plan = self.build_run_plan()
+        progress = initialize_run_progress(
+            plan,
+            created_at_utc="2026-08-24T09:01:00Z",
+        )
+
+        def interrupted_runner(
+                planned_run,
+        ) -> RunnerExecutionResult:
+            raise KeyboardInterrupt
+
+        runners = self.build_runners()
+        runners["pure_python"] = interrupted_runner
+        saved_progress = []
+        timestamps = iter(
+            (
+                "2026-08-24T09:02:00Z",
+                "2026-08-24T09:03:00Z",
+            )
+        )
+
+        with self.assertRaises(
+                KeyboardInterrupt
+        ):
+            execute_next_planned_run(
+                plan,
+                progress,
+                ArchitectureRunnerRegistry(runners),
+                timestamp_provider=lambda: next(
+                    timestamps
+                ),
+                persist_progress=saved_progress.append,
+            )
+
+        interrupted_state = (
+            saved_progress[-1].get_run_state(
+                plan.runs[0].run_id
+            )
+        )
+
+        self.assertEqual(
+            interrupted_state.status,
+            RunStatus.FAILED,
+        )
+        self.assertEqual(
+            interrupted_state.failure_reason,
+            (
+                "Architecture runner was "
+                "interrupted by the user."
+            ),
+        )
+
 if __name__ == "__main__":
     unittest.main()

--- a/benchmarks/experiments/tests/test_controlled_illumination_executor.py
+++ b/benchmarks/experiments/tests/test_controlled_illumination_executor.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import unittest
+
+from benchmarks.experiments.controlled_illumination_executor import (
+    ArchitectureRunnerRegistry,
+    ControlledIlluminationExecutionError,
+    RunnerExecutionResult,
+)
+
+
+class ControlledIlluminationExecutorTests(
+    unittest.TestCase
+):
+    @staticmethod
+    def successful_runner(
+        planned_run,
+    ) -> RunnerExecutionResult:
+        return RunnerExecutionResult(
+            exit_code=0,
+        )
+
+    def build_runners(self) -> dict:
+        return {
+            "pure_python": self.successful_runner,
+            "hybrid": self.successful_runner,
+            "pure_cpp": self.successful_runner,
+        }
+
+    def test_successful_result(
+        self,
+    ) -> None:
+        result = RunnerExecutionResult(
+            exit_code=0,
+            standard_output="completed",
+        )
+
+        self.assertTrue(result.succeeded)
+
+    def test_failed_result(
+        self,
+    ) -> None:
+        result = RunnerExecutionResult(
+            exit_code=1,
+            standard_error="runner failed",
+        )
+
+        self.assertFalse(result.succeeded)
+
+    def test_invalid_exit_code_is_rejected(
+        self,
+    ) -> None:
+        with self.assertRaises(
+            ControlledIlluminationExecutionError
+        ):
+            RunnerExecutionResult(
+                exit_code=True,
+            )
+
+    def test_registry_returns_runner(
+        self,
+    ) -> None:
+        runners = self.build_runners()
+        registry = ArchitectureRunnerRegistry(
+            runners
+        )
+
+        self.assertIs(
+            registry.get_runner("hybrid"),
+            runners["hybrid"],
+        )
+
+    def test_missing_runner_is_rejected(
+        self,
+    ) -> None:
+        runners = self.build_runners()
+        del runners["pure_cpp"]
+
+        with self.assertRaisesRegex(
+            ControlledIlluminationExecutionError,
+            "Missing architecture runners",
+        ):
+            ArchitectureRunnerRegistry(
+                runners
+            )
+
+    def test_unexpected_runner_is_rejected(
+        self,
+    ) -> None:
+        runners = self.build_runners()
+        runners["unknown"] = (
+            self.successful_runner
+        )
+
+        with self.assertRaisesRegex(
+            ControlledIlluminationExecutionError,
+            "Unexpected architecture runners",
+        ):
+            ArchitectureRunnerRegistry(
+                runners
+            )
+
+    def test_unknown_architecture_is_rejected(
+        self,
+    ) -> None:
+        registry = ArchitectureRunnerRegistry(
+            self.build_runners()
+        )
+
+        with self.assertRaisesRegex(
+            ControlledIlluminationExecutionError,
+            "Unsupported execution architecture",
+        ):
+            registry.get_runner(
+                "unknown"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/benchmarks/experiments/tests/test_execute_controlled_illumination_run.py
+++ b/benchmarks/experiments/tests/test_execute_controlled_illumination_run.py
@@ -490,6 +490,34 @@ class ExecuteControlledIlluminationRunTests(
 
         self.assertEqual(exit_code, 130)
 
+    def test_example_runner_configuration_is_valid(
+            self,
+    ) -> None:
+        config_path = (
+                Path(__file__).resolve().parents[1]
+                / "config"
+                / (
+                    "controlled_illumination_"
+                    "runner_config.example.json"
+                )
+        )
+
+        registry = load_runner_registry(
+            config_path
+        )
+
+        for architecture in (
+                "pure_python",
+                "hybrid",
+                "pure_cpp",
+        ):
+            self.assertTrue(
+                callable(
+                    registry.get_runner(
+                        architecture
+                    )
+                )
+            )
 
 if __name__ == "__main__":
     unittest.main()

--- a/benchmarks/experiments/tests/test_execute_controlled_illumination_run.py
+++ b/benchmarks/experiments/tests/test_execute_controlled_illumination_run.py
@@ -1,0 +1,495 @@
+from __future__ import annotations
+
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+import json
+from pathlib import Path
+import subprocess
+import sys
+from tempfile import TemporaryDirectory
+import unittest
+from unittest.mock import patch
+
+from benchmarks.experiments.controlled_illumination_executor import (
+    ControlledIlluminationExecutionError,
+)
+from benchmarks.experiments.controlled_illumination_metadata import (
+    ResolutionMetadata,
+)
+from benchmarks.experiments.controlled_illumination_run_planner import (
+    ControlledIlluminationRunPlan,
+    PlannedRun,
+    write_run_plan_manifests_atomic,
+)
+from benchmarks.experiments.controlled_illumination_run_state import (
+    RunStatus,
+    load_run_progress,
+)
+from benchmarks.experiments.execute_controlled_illumination_run import (
+    build_planned_run_environment,
+    create_argument_parser,
+    determine_progress_path,
+    load_runner_registry,
+    main,
+    run_cli,
+)
+
+
+class ExecuteControlledIlluminationRunTests(
+    unittest.TestCase
+):
+    @staticmethod
+    def build_planned_run() -> PlannedRun:
+        return PlannedRun(
+            execution_order=1,
+            experiment_id="experiment-cli-execution",
+            run_id="experiment-cli-execution-run-0001",
+            phase="constant_lux",
+            platform="desktop",
+            architecture="pure_python",
+            algorithm="clahe",
+            resolution=ResolutionMetadata(
+                width=1280,
+                height=720,
+            ),
+            trial_number=1,
+            incidence_angle_degrees=30.0,
+            target_illuminance_lux=50.0,
+            source_output_setting=None,
+            target_fps=30.0,
+            frame_deadline_ms=1000.0 / 30.0,
+        )
+
+    def build_plan(
+        self,
+    ) -> ControlledIlluminationRunPlan:
+        return ControlledIlluminationRunPlan(
+            schema_version=1,
+            generated_at_utc=(
+                "2026-08-24T10:00:00Z"
+            ),
+            experiment_id=(
+                "experiment-cli-execution"
+            ),
+            randomized=False,
+            randomization_seed=20260824,
+            runs=(
+                self.build_planned_run(),
+            ),
+        )
+
+    @staticmethod
+    def write_runner_config(
+        directory: Path,
+        *,
+        include_pure_cpp: bool = True,
+    ) -> Path:
+        runner_config = {
+            "schema_version": 1,
+            "runners": {
+                "pure_python": {
+                    "arguments": [
+                        sys.executable,
+                        "-c",
+                        "raise SystemExit(0)",
+                    ],
+                    "working_directory": str(
+                        directory
+                    ),
+                    "environment": {
+                        "VISIONLAB_BASE": "configured",
+                    },
+                    "timeout_seconds": 30.0,
+                },
+                "hybrid": {
+                    "arguments": [
+                        sys.executable,
+                        "-c",
+                        "raise SystemExit(0)",
+                    ],
+                    "working_directory": str(
+                        directory
+                    ),
+                },
+            },
+        }
+
+        if include_pure_cpp:
+            runner_config["runners"]["pure_cpp"] = {
+                "arguments": [
+                    sys.executable,
+                    "-c",
+                    "raise SystemExit(0)",
+                ],
+                "working_directory": str(
+                    directory
+                ),
+            }
+
+        config_path = (
+            directory / "runner_config.json"
+        )
+        config_path.write_text(
+            json.dumps(
+                runner_config,
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+        return config_path
+
+    @staticmethod
+    def parse_arguments(
+        plan_path: Path,
+        progress_path: Path,
+        runner_config_path: Path,
+    ):
+        return create_argument_parser().parse_args(
+            [
+                "--plan",
+                str(plan_path),
+                "--progress",
+                str(progress_path),
+                "--runner-config",
+                str(runner_config_path),
+            ]
+        )
+
+    def test_default_progress_path(
+        self,
+    ) -> None:
+        plan_path = Path("experiment/run_plan.json")
+
+        self.assertEqual(
+            determine_progress_path(
+                plan_path,
+                None,
+            ),
+            (
+                plan_path.resolve().parent
+                / "run_progress.json"
+            ),
+        )
+
+    def test_planned_run_environment_is_complete(
+        self,
+    ) -> None:
+        environment = build_planned_run_environment(
+            self.build_planned_run()
+        )
+
+        self.assertEqual(
+            environment["VISIONLAB_RUN_ID"],
+            "experiment-cli-execution-run-0001",
+        )
+        self.assertEqual(
+            environment["VISIONLAB_ALGORITHM"],
+            "clahe",
+        )
+        self.assertEqual(
+            environment[
+                "VISIONLAB_RESOLUTION_WIDTH"
+            ],
+            "1280",
+        )
+        self.assertEqual(
+            environment[
+                "VISIONLAB_TARGET_ILLUMINANCE_LUX"
+            ],
+            "50.0",
+        )
+        self.assertEqual(
+            environment[
+                "VISIONLAB_SOURCE_OUTPUT_SETTING"
+            ],
+            "",
+        )
+
+    def test_runner_config_requires_all_architectures(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary:
+            config_path = self.write_runner_config(
+                Path(temporary),
+                include_pure_cpp=False,
+            )
+
+            with self.assertRaisesRegex(
+                ControlledIlluminationExecutionError,
+                "architectures do not match",
+            ):
+                load_runner_registry(
+                    config_path
+                )
+
+    def test_runner_config_merges_run_environment(
+        self,
+    ) -> None:
+        completed_process = subprocess.CompletedProcess(
+            args=(sys.executable,),
+            returncode=0,
+            stdout="completed",
+            stderr="",
+        )
+
+        with TemporaryDirectory() as temporary:
+            temporary_path = Path(temporary)
+            config_path = self.write_runner_config(
+                temporary_path
+            )
+            registry = load_runner_registry(
+                config_path
+            )
+
+            with patch(
+                "benchmarks.experiments."
+                "controlled_illumination_executor."
+                "subprocess.run",
+                return_value=completed_process,
+            ) as run_mock:
+                result = registry.get_runner(
+                    "pure_python"
+                )(
+                    self.build_planned_run()
+                )
+
+        self.assertTrue(result.succeeded)
+        execution_environment = (
+            run_mock.call_args.kwargs["env"]
+        )
+        self.assertEqual(
+            execution_environment["VISIONLAB_BASE"],
+            "configured",
+        )
+        self.assertEqual(
+            execution_environment["VISIONLAB_RUN_ID"],
+            "experiment-cli-execution-run-0001",
+        )
+
+    def test_run_cli_completes_and_persists_run(
+        self,
+    ) -> None:
+        completed_process = subprocess.CompletedProcess(
+            args=(sys.executable,),
+            returncode=0,
+            stdout="completed",
+            stderr="",
+        )
+
+        with TemporaryDirectory() as temporary:
+            temporary_path = Path(temporary)
+            plan = self.build_plan()
+            plan_path, _ = (
+                write_run_plan_manifests_atomic(
+                    plan,
+                    temporary_path,
+                )
+            )
+            progress_path = (
+                temporary_path
+                / "run_progress.json"
+            )
+            config_path = self.write_runner_config(
+                temporary_path
+            )
+            arguments = self.parse_arguments(
+                plan_path,
+                progress_path,
+                config_path,
+            )
+            timestamps = iter(
+                (
+                    "2026-08-24T10:01:00Z",
+                    "2026-08-24T10:02:00Z",
+                    "2026-08-24T10:03:00Z",
+                )
+            )
+
+            with patch(
+                "benchmarks.experiments."
+                "controlled_illumination_executor."
+                "subprocess.run",
+                return_value=completed_process,
+            ):
+                with redirect_stdout(StringIO()):
+                    exit_code = run_cli(
+                        arguments,
+                        timestamp_provider=lambda: next(
+                            timestamps
+                        ),
+                    )
+
+            progress = load_run_progress(
+                progress_path,
+                plan=plan,
+            )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(
+            progress.get_run_state(
+                plan.runs[0].run_id
+            ).status,
+            RunStatus.COMPLETED,
+        )
+
+    def test_run_cli_reports_runner_failure(
+        self,
+    ) -> None:
+        failed_process = subprocess.CompletedProcess(
+            args=(sys.executable,),
+            returncode=5,
+            stdout="",
+            stderr="runner failed",
+        )
+
+        with TemporaryDirectory() as temporary:
+            temporary_path = Path(temporary)
+            plan = self.build_plan()
+            plan_path, _ = (
+                write_run_plan_manifests_atomic(
+                    plan,
+                    temporary_path,
+                )
+            )
+            progress_path = (
+                temporary_path
+                / "run_progress.json"
+            )
+            config_path = self.write_runner_config(
+                temporary_path
+            )
+            arguments = self.parse_arguments(
+                plan_path,
+                progress_path,
+                config_path,
+            )
+            timestamps = iter(
+                (
+                    "2026-08-24T10:01:00Z",
+                    "2026-08-24T10:02:00Z",
+                    "2026-08-24T10:03:00Z",
+                )
+            )
+
+            with patch(
+                "benchmarks.experiments."
+                "controlled_illumination_executor."
+                "subprocess.run",
+                return_value=failed_process,
+            ):
+                with redirect_stderr(StringIO()):
+                    exit_code = run_cli(
+                        arguments,
+                        timestamp_provider=lambda: next(
+                            timestamps
+                        ),
+                    )
+
+            progress = load_run_progress(
+                progress_path,
+                plan=plan,
+            )
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(
+            progress.get_run_state(
+                plan.runs[0].run_id
+            ).status,
+            RunStatus.FAILED,
+        )
+
+    def test_run_cli_reports_no_remaining_runs(
+        self,
+    ) -> None:
+        completed_process = subprocess.CompletedProcess(
+            args=(sys.executable,),
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+        with TemporaryDirectory() as temporary:
+            temporary_path = Path(temporary)
+            plan = self.build_plan()
+            plan_path, _ = (
+                write_run_plan_manifests_atomic(
+                    plan,
+                    temporary_path,
+                )
+            )
+            progress_path = (
+                temporary_path
+                / "run_progress.json"
+            )
+            config_path = self.write_runner_config(
+                temporary_path
+            )
+            arguments = self.parse_arguments(
+                plan_path,
+                progress_path,
+                config_path,
+            )
+            timestamps = iter(
+                (
+                    "2026-08-24T10:01:00Z",
+                    "2026-08-24T10:02:00Z",
+                    "2026-08-24T10:03:00Z",
+                )
+            )
+
+            with patch(
+                "benchmarks.experiments."
+                "controlled_illumination_executor."
+                "subprocess.run",
+                return_value=completed_process,
+            ):
+                with redirect_stdout(StringIO()):
+                    first_exit_code = run_cli(
+                        arguments,
+                        timestamp_provider=lambda: next(
+                            timestamps
+                        ),
+                    )
+
+            captured_output = StringIO()
+
+            with redirect_stdout(captured_output):
+                second_exit_code = run_cli(
+                    arguments,
+                    timestamp_provider=lambda: (
+                        "2026-08-24T10:04:00Z"
+                    ),
+                )
+
+        self.assertEqual(first_exit_code, 0)
+        self.assertEqual(second_exit_code, 0)
+        self.assertIn(
+            "No planned experiment runs remain",
+            captured_output.getvalue(),
+        )
+
+    def test_main_returns_interrupt_exit_code(
+        self,
+    ) -> None:
+        with patch(
+            "benchmarks.experiments."
+            "execute_controlled_illumination_run."
+            "run_cli",
+            side_effect=KeyboardInterrupt,
+        ):
+            with redirect_stderr(StringIO()):
+                exit_code = main(
+                    [
+                        "--plan",
+                        "run_plan.json",
+                        "--runner-config",
+                        "runner_config.json",
+                    ]
+                )
+
+        self.assertEqual(exit_code, 130)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add architecture-runner registration and subprocess execution
- select the next planned controlled-illumination run
- persist `running`, `completed`, and `failed` transitions atomically
- resume execution from an existing `run_progress.json`
- add runner configuration loading for Pure Python, Hybrid, and Pure C++
- pass planned run conditions through `VISIONLAB_*` environment variables
- add a CLI for executing the next planned run
- handle runner failures, timeouts, invalid results, and user interruption
- document runner configuration and execution workflow

## Validation

- all controlled-illumination experiment tests pass
- example runner configuration passes JSON and schema validation
- Markdown code fences are balanced
- `git diff --check` passes
- no merge-conflict markers are present

## Notes

The committed runner configuration contains placeholders only. Real
architecture-specific runner paths must be configured for each target
platform before official experiments.

Generated progress files and local runner configurations remain
untracked experiment artifacts.

Closes #34 