### PR TITLE
fix: validate controlled-illumination timing and summary statistics

### DIFF
--- a/benchmarks/experiments/README.md
+++ b/benchmarks/experiments/README.md
@@ -832,10 +832,15 @@ The finalization process:
 6. Validates the run metadata against the planned condition.
 7. Validates warm-up and measured-frame counts.
 8. Validates the complete frame-results CSV, including row identities,
-   sequential frame indices, frame statuses and deadline statistics.
-9. Verifies the frame-results SHA-256 hash.
-10. Records each required artifact's SHA-256 hash and file size.
-11. Atomically publishes an immutable bundle manifest without
+   sequential frame indices, frame statuses, timestamp-derived timings,
+   deadline classifications and deadline statistics. Derived timings and
+   summary means use a `1e-6 ms` absolute tolerance to accommodate the
+   CSV's six-decimal serialization.
+9. Recomputes mean processing time and mean end-to-end latency from the
+   processed frame records and checks them against the execution summary.
+10. Verifies the frame-results SHA-256 hash.
+11. Records each required artifact's SHA-256 hash and file size.
+12. Atomically publishes an immutable bundle manifest without
     overwriting an existing manifest.
 
 Run the finalizer from the repository root:
@@ -911,6 +916,8 @@ Finalization is rejected when:
 * The execution summary does not match the planned run.
 * Frame counts do not match the experiment configuration.
 * The frame-results CSV contains missing, duplicate or invalid frame records.
+* Timestamp-derived timings, deadline classification or summary means are
+  inconsistent with the frame-level records.
 * The frame-results hash does not match the execution summary.
 * The finalization timestamp precedes the execution finish time.
 * A bundle manifest already exists.

--- a/benchmarks/experiments/controlled_illumination_run_bundle.py
+++ b/benchmarks/experiments/controlled_illumination_run_bundle.py
@@ -293,20 +293,20 @@ def validate_summary_frame_hash(
         )
 
 def validate_derived_timing(
-        record: RealtimeFrameRecord,
-        field_name: str,
-        expected_value: float,
+    record: RealtimeFrameRecord,
+    field_name: str,
+    expected_value: float,
 ) -> None:
     actual_value = getattr(record, field_name)
 
     if (
-            actual_value is None
-            or not math.isclose(
-        actual_value,
-        expected_value,
-        rel_tol=0.0,
-        abs_tol=TIMING_ABS_TOLERANCE_MS,
-    )
+        actual_value is None
+        or not math.isclose(
+            actual_value,
+            expected_value,
+            rel_tol=0.0,
+            abs_tol=TIMING_ABS_TOLERANCE_MS,
+        )
     ):
         raise ControlledIlluminationRunBundleError(
             f"Frame {record.frame_index} {field_name} "

--- a/benchmarks/experiments/controlled_illumination_run_bundle.py
+++ b/benchmarks/experiments/controlled_illumination_run_bundle.py
@@ -38,6 +38,7 @@ from benchmarks.realtime.realtime_records import (
 )
 
 RUN_BUNDLE_SCHEMA_VERSION = 1
+TIMING_ABS_TOLERANCE_MS = 1e-6
 
 RUN_METADATA_FILE_NAME = "run_metadata.json"
 
@@ -289,6 +290,83 @@ def validate_summary_frame_hash(
             "Frame-results SHA-256 does not match "
             "the execution summary."
         )
+
+def validate_derived_timing(
+        record: RealtimeFrameRecord,
+        field_name: str,
+        expected_value: float,
+) -> None:
+    actual_value = getattr(record, field_name)
+
+    if (
+            actual_value is None
+            or not math.isclose(
+        actual_value,
+        expected_value,
+        rel_tol=0.0,
+        abs_tol=TIMING_ABS_TOLERANCE_MS,
+    )
+    ):
+        raise ControlledIlluminationRunBundleError(
+            f"Frame {record.frame_index} {field_name} "
+            "does not match its timestamp-derived "
+            "value."
+        )
+
+def validate_frame_timing_consistency(
+    record: RealtimeFrameRecord,
+) -> None:
+    if record.frame_status is FrameStatus.SKIPPED:
+        return
+
+    if record.enqueued_timestamp_ms is None:
+        raise ControlledIlluminationRunBundleError(
+            f"Frame {record.frame_index} is missing "
+            "its enqueue timestamp."
+        )
+
+    validate_derived_timing(
+        record,
+        "source_delay_ms",
+        (
+            record.enqueued_timestamp_ms
+            - record.scheduled_timestamp_ms
+        ),
+    )
+
+    if record.frame_status is FrameStatus.DROPPED:
+        return
+
+    if (
+        record.processing_start_timestamp_ms is None
+        or record.processing_end_timestamp_ms is None
+    ):
+        raise ControlledIlluminationRunBundleError(
+            f"Frame {record.frame_index} is missing "
+            "processing timestamps."
+        )
+
+    processing_start_ms = (
+        record.processing_start_timestamp_ms
+    )
+    processing_end_ms = (
+        record.processing_end_timestamp_ms
+    )
+
+    validate_derived_timing(
+        record,
+        "queue_wait_time_ms",
+        (
+            processing_start_ms
+            - record.enqueued_timestamp_ms
+        ),
+    )
+
+    validate_derived_timing(
+        record,
+        "processing_time_ms",
+        processing_end_ms - processing_start_ms,
+    )
 
 def validate_frame_results_against_run(
     frame_results_path: Path,
@@ -652,6 +730,10 @@ def validate_frame_results_against_run(
                         )
                     )
 
+                validate_frame_timing_consistency(
+                    record,
+                )
+
                 records.append(record)
 
     except UnicodeError as error:
@@ -744,6 +826,7 @@ def validate_frame_results_against_run(
             "Deadline-met count does not match "
             "the execution summary."
         )
+
 
 def validate_bundle_identifier(
     value: Any,

--- a/benchmarks/experiments/controlled_illumination_run_bundle.py
+++ b/benchmarks/experiments/controlled_illumination_run_bundle.py
@@ -9,6 +9,7 @@ import math
 import os
 from uuid import uuid4
 from collections import Counter
+from statistics import fmean
 import csv
 
 from benchmarks.experiments.controlled_illumination_metadata import (
@@ -315,6 +316,7 @@ def validate_derived_timing(
 
 def validate_frame_timing_consistency(
     record: RealtimeFrameRecord,
+    frame_deadline_ms: float,
 ) -> None:
     if record.frame_status is FrameStatus.SKIPPED:
         return
@@ -367,6 +369,82 @@ def validate_frame_timing_consistency(
         "processing_time_ms",
         processing_end_ms - processing_start_ms,
     )
+
+    expected_end_to_end_latency_ms = (
+        processing_end_ms
+        - record.scheduled_timestamp_ms
+    )
+
+    validate_derived_timing(
+        record,
+        "end_to_end_latency_ms",
+        expected_end_to_end_latency_ms,
+    )
+
+    expected_deadline_missed = (
+        expected_end_to_end_latency_ms
+        > frame_deadline_ms
+    )
+
+    if (
+        record.deadline_missed
+        is not expected_deadline_missed
+    ):
+        raise ControlledIlluminationRunBundleError(
+            f"Frame {record.frame_index} "
+            "deadline_missed does not match the "
+            "timestamp-derived latency and configured "
+            "frame deadline."
+        )
+
+def validate_summary_timing_mean(
+    records: list[RealtimeFrameRecord],
+    summary: ControlledIlluminationExecutionSummary,
+    timing_field: str,
+    summary_field: str,
+) -> None:
+    timing_values = [
+        getattr(record, timing_field)
+        for record in records
+        if record.frame_status is FrameStatus.PROCESSED
+    ]
+
+    if not timing_values:
+        return
+
+    if any(
+        value is None
+        for value in timing_values
+    ):
+        raise ControlledIlluminationRunBundleError(
+            "Processed frame records are missing "
+            f"{timing_field}."
+        )
+
+    expected_mean = fmean(
+        value
+        for value in timing_values
+        if value is not None
+    )
+    actual_mean = getattr(
+        summary,
+        summary_field,
+    )
+
+    if (
+        actual_mean is None
+        or not math.isclose(
+            actual_mean,
+            expected_mean,
+            rel_tol=0.0,
+            abs_tol=TIMING_ABS_TOLERANCE_MS,
+        )
+    ):
+        raise ControlledIlluminationRunBundleError(
+            f"Execution-summary {summary_field} "
+            "does not match the processed frame "
+            "records."
+        )
 
 def validate_frame_results_against_run(
     frame_results_path: Path,
@@ -732,6 +810,7 @@ def validate_frame_results_against_run(
 
                 validate_frame_timing_consistency(
                     record,
+                    planned_run.frame_deadline_ms,
                 )
 
                 records.append(record)
@@ -797,6 +876,20 @@ def validate_frame_results_against_run(
             "Skipped-frame count does not match "
             "the execution summary."
         )
+
+    validate_summary_timing_mean(
+        records,
+        summary,
+        "processing_time_ms",
+        "mean_processing_time_ms",
+    )
+
+    validate_summary_timing_mean(
+        records,
+        summary,
+        "end_to_end_latency_ms",
+        "mean_end_to_end_latency_ms",
+    )
 
     deadline_miss_count = sum(
         record.frame_status == FrameStatus.PROCESSED

--- a/benchmarks/experiments/tests/test_controlled_illumination_run_bundle.py
+++ b/benchmarks/experiments/tests/test_controlled_illumination_run_bundle.py
@@ -1367,7 +1367,7 @@ class ControlledIlluminationRunBundleTests(
             "2.0",
             "queue_wait_time_ms",
         )
-        
+
     def test_inconsistent_processing_time_is_rejected(
         self,
     ) -> None:
@@ -1652,7 +1652,7 @@ class ControlledIlluminationRunBundleTests(
             "8.0",
             "end_to_end_latency_ms",
         )
-        
+
     def test_incorrect_deadline_classification_is_rejected(
         self,
     ) -> None:

--- a/benchmarks/experiments/tests/test_controlled_illumination_run_bundle.py
+++ b/benchmarks/experiments/tests/test_controlled_illumination_run_bundle.py
@@ -1,4 +1,4 @@
-from dataclasses import replace
+
 import unittest
 import hashlib
 from pathlib import Path
@@ -476,6 +476,50 @@ class ControlledIlluminationRunBundleTests(
                     frame_results_path,
                     planned_run,
                     summary,
+                )
+
+    def assert_summary_mean_is_rejected(
+        self,
+        field_name: str,
+    ) -> None:
+        with TemporaryDirectory() as temporary:
+            run_directory = Path(temporary)
+            (
+                _,
+                _,
+                planned_run,
+                frame_results_path,
+            ) = self.prepare_finalizable_run(
+                run_directory
+            )
+            summary = load_execution_summary(
+                run_directory
+            )
+            actual_mean = getattr(
+                summary,
+                field_name,
+            )
+
+            if actual_mean is None:
+                self.fail(
+                    f"{field_name} unexpectedly null."
+                )
+
+            mismatched_summary = replace(
+                summary,
+                **{
+                    field_name: actual_mean + 1.0,
+                },
+            )
+
+            with self.assertRaisesRegex(
+                ControlledIlluminationRunBundleError,
+                field_name,
+            ):
+                validate_frame_results_against_run(
+                    frame_results_path,
+                    planned_run,
+                    mismatched_summary,
                 )
 
     def test_valid_manifest_is_serialized(
@@ -1600,6 +1644,207 @@ class ControlledIlluminationRunBundleTests(
                 [],
             )
 
+    def test_inconsistent_end_to_end_latency_is_rejected(
+        self,
+    ) -> None:
+        self.assert_frame_result_field_is_rejected(
+            "end_to_end_latency_ms",
+            "8.0",
+            "end_to_end_latency_ms",
+        )
+        
+    def test_incorrect_deadline_classification_is_rejected(
+        self,
+    ) -> None:
+        self.assert_frame_result_field_is_rejected(
+            "deadline_missed",
+            "true",
+            "deadline_missed",
+        )
+
+    def test_incorrect_mean_processing_time_is_rejected(
+        self,
+    ) -> None:
+        self.assert_summary_mean_is_rejected(
+            "mean_processing_time_ms",
+        )
+
+    def test_incorrect_mean_end_to_end_latency_is_rejected(
+        self,
+    ) -> None:
+        self.assert_summary_mean_is_rejected(
+            "mean_end_to_end_latency_ms",
+        )
+
+    def test_six_decimal_timing_tolerance_is_accepted(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary:
+            run_directory = Path(temporary)
+            (
+                _,
+                _,
+                planned_run,
+                frame_results_path,
+            ) = self.prepare_finalizable_run(
+                run_directory
+            )
+            summary = load_execution_summary(
+                run_directory
+            )
+            fieldnames, rows = (
+                self.read_frame_result_rows(
+                    frame_results_path
+                )
+            )
+
+            rows[0]["source_delay_ms"] = "1.000001"
+
+            self.write_frame_result_rows(
+                frame_results_path,
+                fieldnames,
+                rows,
+            )
+
+            rounded_summary = replace(
+                summary,
+                mean_processing_time_ms=(
+                    summary.mean_processing_time_ms
+                    + 0.0000005
+                ),
+                mean_end_to_end_latency_ms=(
+                    summary.mean_end_to_end_latency_ms
+                    + 0.0000005
+                ),
+            )
+
+            validate_frame_results_against_run(
+                frame_results_path,
+                planned_run,
+                rounded_summary,
+            )
+
+    def test_zero_processed_frames_accept_null_means(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary:
+            run_directory = Path(temporary)
+            (
+                _,
+                _,
+                planned_run,
+                frame_results_path,
+            ) = self.prepare_finalizable_run(
+                run_directory
+            )
+            summary = load_execution_summary(
+                run_directory
+            )
+            fieldnames, rows = (
+                self.read_frame_result_rows(
+                    frame_results_path
+                )
+            )
+
+            for row in rows:
+                row["drop_timestamp_ms"] = (
+                    row["processing_start_timestamp_ms"]
+                )
+
+                for field_name in (
+                    "processing_start_timestamp_ms",
+                    "processing_end_timestamp_ms",
+                    "queue_wait_time_ms",
+                    "processing_time_ms",
+                    "end_to_end_latency_ms",
+                    "deadline_missed",
+                ):
+                    row[field_name] = ""
+
+                row["frame_status"] = "dropped"
+
+            self.write_frame_result_rows(
+                frame_results_path,
+                fieldnames,
+                rows,
+            )
+
+            dropped_summary = replace(
+                summary,
+                processed_frame_count=0,
+                dropped_frame_count=(
+                    summary.measured_frame_count
+                ),
+                deadline_met_count=0,
+                mean_processing_time_ms=None,
+                mean_end_to_end_latency_ms=None,
+            )
+
+            validate_frame_results_against_run(
+                frame_results_path,
+                planned_run,
+                dropped_summary,
+            )
+
+    def test_skipped_frame_status_fields_remain_valid(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary:
+            run_directory = Path(temporary)
+            (
+                _,
+                _,
+                planned_run,
+                frame_results_path,
+            ) = self.prepare_finalizable_run(
+                run_directory
+            )
+            summary = load_execution_summary(
+                run_directory
+            )
+            fieldnames, rows = (
+                self.read_frame_result_rows(
+                    frame_results_path
+                )
+            )
+
+            for field_name in (
+                "enqueued_timestamp_ms",
+                "processing_start_timestamp_ms",
+                "processing_end_timestamp_ms",
+                "drop_timestamp_ms",
+                "source_delay_ms",
+                "queue_wait_time_ms",
+                "processing_time_ms",
+                "end_to_end_latency_ms",
+                "deadline_missed",
+            ):
+                rows[0][field_name] = ""
+
+            rows[0]["frame_status"] = "skipped"
+
+            self.write_frame_result_rows(
+                frame_results_path,
+                fieldnames,
+                rows,
+            )
+
+            skipped_summary = replace(
+                summary,
+                processed_frame_count=(
+                    summary.processed_frame_count - 1
+                ),
+                skipped_frame_count=1,
+                deadline_met_count=(
+                    summary.deadline_met_count - 1
+                ),
+            )
+
+            validate_frame_results_against_run(
+                frame_results_path,
+                planned_run,
+                skipped_summary,
+            )
 
 if __name__ == "__main__":
     unittest.main()

--- a/benchmarks/experiments/tests/test_controlled_illumination_run_bundle.py
+++ b/benchmarks/experiments/tests/test_controlled_illumination_run_bundle.py
@@ -435,6 +435,49 @@ class ControlledIlluminationRunBundleTests(
 
         return output_path
 
+    def assert_frame_result_field_is_rejected(
+        self,
+        field_name: str,
+        replacement_value: str,
+        expected_message: str,
+    ) -> None:
+        with TemporaryDirectory() as temporary:
+            run_directory = Path(temporary)
+            (
+                _,
+                _,
+                planned_run,
+                frame_results_path,
+            ) = self.prepare_finalizable_run(
+                run_directory
+            )
+            summary = load_execution_summary(
+                run_directory
+            )
+            fieldnames, rows = (
+                self.read_frame_result_rows(
+                    frame_results_path
+                )
+            )
+
+            rows[0][field_name] = replacement_value
+
+            self.write_frame_result_rows(
+                frame_results_path,
+                fieldnames,
+                rows,
+            )
+
+            with self.assertRaisesRegex(
+                ControlledIlluminationRunBundleError,
+                expected_message,
+            ):
+                validate_frame_results_against_run(
+                    frame_results_path,
+                    planned_run,
+                    summary,
+                )
+
     def test_valid_manifest_is_serialized(
         self,
     ) -> None:
@@ -1262,6 +1305,33 @@ class ControlledIlluminationRunBundleTests(
                 planned_run,
                 summary,
             )
+
+    def test_inconsistent_source_delay_is_rejected(
+        self,
+    ) -> None:
+        self.assert_frame_result_field_is_rejected(
+            "source_delay_ms",
+            "2.0",
+            "source_delay_ms",
+        )
+
+    def test_inconsistent_queue_wait_time_is_rejected(
+        self,
+    ) -> None:
+        self.assert_frame_result_field_is_rejected(
+            "queue_wait_time_ms",
+            "2.0",
+            "queue_wait_time_ms",
+        )
+        
+    def test_inconsistent_processing_time_is_rejected(
+        self,
+    ) -> None:
+        self.assert_frame_result_field_is_rejected(
+            "processing_time_ms",
+            "6.0",
+            "processing_time_ms",
+        )
 
     def test_duplicate_frame_index_is_rejected(
             self,


### PR DESCRIPTION
## Summary

- Validate timestamp-derived frame timing fields.
- Recompute deadline-miss classifications from configured deadlines.
- Cross-check execution-summary means against processed frame records.
- Preserve dropped, skipped and zero-processed-frame behavior.
- Document the six-decimal CSV tolerance.

## Testing

- 55 run-bundle tests passed
- 225 experiment tests passed
- 45 real-time tests passed
- `git diff --check` passed

Closes #40 