### PR TITLE
feat: add configurable live-camera input for controlled-illumination pure-Python runs

### DIFF
--- a/benchmarks/experiments/README.md
+++ b/benchmarks/experiments/README.md
@@ -779,6 +779,51 @@ controlled-illumination measurements. Official lux- and angle-dependent
 experiments require the live-camera input adapter and calibrated
 illumination hardware.
 
+#### Pure Python live-camera input
+
+The controlled-illumination Pure Python runner supports deterministic
+video and live-camera input.
+
+Deterministic video remains the default:
+
+```text
+VISIONLAB_INPUT_SOURCE=video
+```
+
+Video input uses the path configured by `input.video_path` in the
+benchmark configuration.
+
+Select a live camera through the Pure Python runner environment:
+
+```json
+{
+  "environment": {
+    "VISIONLAB_INPUT_SOURCE": "camera",
+    "VISIONLAB_CAMERA_INDEX": "0"
+  }
+}
+```
+
+`VISIONLAB_CAMERA_INDEX` must contain a non-negative integer identifying
+the OpenCV capture device. It is required only when
+`VISIONLAB_INPUT_SOURCE=camera`.
+
+The runner rejects unsupported input-source values, missing camera
+indices, negative indices and non-integer indices before starting the
+trial. Camera-open, frame-read and empty-frame failures abort the run
+without writing completed-run artifacts. The OpenCV capture device is
+released when the frame iterator finishes or fails.
+
+Live-camera input is currently supported only by the Pure Python
+controlled-illumination runner. The Hybrid and Pure C++ runners continue
+to use the deterministic benchmark video.
+
+A successful live-camera run verifies capture and processing
+integration only. It must not be interpreted as an official physical
+controlled-illumination experiment until exposure, sensor gain or ISO,
+white balance, focus, frame rate, resolution and calibration have been
+configured and verified according to the experiment protocol.
+
 ### Run environment
 
 The orchestrator passes the selected condition to the architecture

--- a/benchmarks/experiments/controlled_illumination_pure_python_runner.py
+++ b/benchmarks/experiments/controlled_illumination_pure_python_runner.py
@@ -7,7 +7,6 @@ import os
 import sys
 from typing import Any
 
-
 from benchmarks.experiments.controlled_illumination_run_artifacts import (
     write_completed_run_artifacts_atomic,
 )

--- a/benchmarks/experiments/controlled_illumination_pure_python_runner.py
+++ b/benchmarks/experiments/controlled_illumination_pure_python_runner.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping
 from datetime import datetime, timezone
 import math
+import os
 import sys
 from typing import Any
+
 
 from benchmarks.experiments.controlled_illumination_run_artifacts import (
     write_completed_run_artifacts_atomic,
@@ -28,12 +30,23 @@ from benchmarks.realtime.realtime_experiment_plan import (
     validate_shared_execution_counts,
 )
 from benchmarks.realtime.realtime_pipeline import (
+    iter_camera_frames,
     iter_video_frames,
     run_realtime_trial,
 )
 
 
 PURE_PYTHON_ARCHITECTURE = "pure_python"
+
+INPUT_SOURCE_VARIABLE = (
+    "VISIONLAB_INPUT_SOURCE"
+)
+
+VIDEO_INPUT_SOURCE = "video"
+CAMERA_INPUT_SOURCE = "camera"
+CAMERA_INDEX_VARIABLE = (
+    "VISIONLAB_CAMERA_INDEX"
+)
 
 
 class ControlledIlluminationPurePythonRunnerError(
@@ -47,6 +60,86 @@ def current_utc_timestamp() -> str:
         datetime.now(timezone.utc)
         .isoformat()
         .replace("+00:00", "Z")
+    )
+
+
+def create_frame_source(
+    benchmark_config: dict[str, Any],
+    *,
+    environment: Mapping[str, str] | None = None,
+) -> Any:
+    active_environment = (
+        os.environ
+        if environment is None
+        else environment
+    )
+
+    raw_input_source = active_environment.get(
+        INPUT_SOURCE_VARIABLE,
+        VIDEO_INPUT_SOURCE,
+    )
+
+    if (
+        not isinstance(raw_input_source, str)
+        or not raw_input_source.strip()
+    ):
+        raise ControlledIlluminationPurePythonRunnerError(
+            f"{INPUT_SOURCE_VARIABLE} must contain "
+            "a non-empty string."
+        )
+
+    input_source = (
+        raw_input_source.strip().lower()
+    )
+
+    if input_source == VIDEO_INPUT_SOURCE:
+        video_path = resolve_video_path(
+            benchmark_config
+        )
+
+        return iter_video_frames(
+            video_path
+        )
+
+    if input_source == CAMERA_INPUT_SOURCE:
+        raw_camera_index = (
+            active_environment.get(
+                CAMERA_INDEX_VARIABLE
+            )
+        )
+
+        if (
+            not isinstance(raw_camera_index, str)
+            or not raw_camera_index.strip()
+        ):
+            raise ControlledIlluminationPurePythonRunnerError(
+                f"{CAMERA_INDEX_VARIABLE} must be "
+                "a non-negative integer."
+            )
+
+        try:
+            camera_index = int(
+                raw_camera_index
+            )
+        except ValueError as error:
+            raise ControlledIlluminationPurePythonRunnerError(
+                f"{CAMERA_INDEX_VARIABLE} must be "
+                "a non-negative integer."
+            ) from error
+
+        if camera_index < 0:
+            raise ControlledIlluminationPurePythonRunnerError(
+                f"{CAMERA_INDEX_VARIABLE} must be "
+                "a non-negative integer."
+            )
+
+        return iter_camera_frames(
+            camera_index
+        )
+
+    raise ControlledIlluminationPurePythonRunnerError(
+        "Unsupported input source: "
+        f"{input_source}"
     )
 
 
@@ -160,16 +253,15 @@ def execute_pure_python_run(
     frame_processor = create_frame_processor(
         algorithm_config
     )
-    video_path = resolve_video_path(
-        benchmark_config
+    frame_source = create_frame_source(
+        benchmark_config,
+        environment=environment,
     )
 
     started_at_utc = now_provider()
 
     frame_records = run_realtime_trial(
-        frame_source=iter_video_frames(
-            video_path
-        ),
+        frame_source=frame_source,
         processor=frame_processor,
         config=realtime_config,
         architecture=planned_run.architecture,

--- a/benchmarks/experiments/tests/test_controlled_illumination_pure_python_runner.py
+++ b/benchmarks/experiments/tests/test_controlled_illumination_pure_python_runner.py
@@ -25,6 +25,10 @@ from benchmarks.experiments.controlled_illumination_runner_context import (
     ControlledIlluminationRunnerContext,
 )
 
+from benchmarks.experiments import (
+    controlled_illumination_pure_python_runner
+    as pure_python_runner,
+)
 
 RUNNER_MODULE = (
     "benchmarks.experiments."
@@ -247,8 +251,11 @@ class ControlledIlluminationPurePythonRunnerTests(
         }
         processor = object()
         frame_source = object()
+        environment = {
+            "VISIONLAB_INPUT_SOURCE": "camera",
+            "VISIONLAB_CAMERA_INDEX": "2",
+        }
         records = (object(),)
-        video_path = Path("benchmark_input.mp4")
         expected_paths = (
             Path("realtime_frame_results.csv"),
             Path("execution_summary.json"),
@@ -297,14 +304,9 @@ class ControlledIlluminationPurePythonRunnerTests(
             ),
             patch(
                 f"{RUNNER_MODULE}."
-                "resolve_video_path",
-                return_value=video_path,
-            ),
-            patch(
-                f"{RUNNER_MODULE}."
-                "iter_video_frames",
+                "create_frame_source",
                 return_value=frame_source,
-            ),
+            ) as create_source,
             patch(
                 f"{RUNNER_MODULE}."
                 "run_realtime_trial",
@@ -317,9 +319,10 @@ class ControlledIlluminationPurePythonRunnerTests(
             ) as write_artifacts,
         ):
             actual_paths = execute_pure_python_run(
+                environment,
                 now_provider=lambda: next(
                     timestamps
-                )
+                ),
             )
 
         self.assertEqual(
@@ -327,8 +330,12 @@ class ControlledIlluminationPurePythonRunnerTests(
             expected_paths,
         )
         load_context.assert_called_once_with(
-            None,
+            environment,
             expected_architecture="pure_python",
+        )
+        create_source.assert_called_once_with(
+            benchmark_config,
+            environment=environment,
         )
         run_trial.assert_called_once_with(
             frame_source=frame_source,
@@ -395,6 +402,247 @@ class ControlledIlluminationPurePythonRunnerTests(
             captured_output.getvalue(),
         )
 
+    def test_video_input_is_default(
+        self,
+    ) -> None:
+        benchmark_config = {
+            "test": "benchmark-config",
+        }
+        video_path = Path(
+            "benchmark_input.mp4"
+        )
+        frame_source = object()
+
+        with (
+            patch(
+                f"{RUNNER_MODULE}."
+                "resolve_video_path",
+                return_value=video_path,
+            ) as resolve_video,
+            patch(
+                f"{RUNNER_MODULE}."
+                "iter_video_frames",
+                return_value=frame_source,
+            ) as iter_video,
+        ):
+            selected_source = (
+                pure_python_runner
+                .create_frame_source(
+                    benchmark_config,
+                    environment={},
+                )
+            )
+
+        self.assertIs(
+            selected_source,
+            frame_source,
+        )
+        resolve_video.assert_called_once_with(
+            benchmark_config
+        )
+        iter_video.assert_called_once_with(
+            video_path
+        )
+
+    def test_unsupported_input_source_is_rejected(
+        self,
+    ) -> None:
+        benchmark_config = {
+            "test": "benchmark-config",
+        }
+
+        with (
+            patch(
+                f"{RUNNER_MODULE}."
+                "resolve_video_path",
+                return_value=Path(
+                    "benchmark_input.mp4"
+                ),
+            ),
+            patch(
+                f"{RUNNER_MODULE}."
+                "iter_video_frames",
+                return_value=object(),
+            ),
+        ):
+            with self.assertRaisesRegex(
+                ControlledIlluminationPurePythonRunnerError,
+                "Unsupported input source: usb",
+            ):
+                pure_python_runner.create_frame_source(
+                    benchmark_config,
+                    environment={
+                        "VISIONLAB_INPUT_SOURCE": "usb",
+                    },
+                )
+
+    def test_camera_input_uses_configured_index(
+        self,
+    ) -> None:
+        benchmark_config = {
+            "test": "benchmark-config",
+        }
+        frame_source = object()
+
+        with (
+            patch(
+                f"{RUNNER_MODULE}."
+                "iter_camera_frames",
+                create=True,
+                return_value=frame_source,
+            ) as iter_camera,
+            patch(
+                f"{RUNNER_MODULE}."
+                "resolve_video_path",
+            ) as resolve_video,
+            patch(
+                f"{RUNNER_MODULE}."
+                "iter_video_frames",
+            ) as iter_video,
+        ):
+            selected_source = (
+                pure_python_runner
+                .create_frame_source(
+                    benchmark_config,
+                    environment={
+                        "VISIONLAB_INPUT_SOURCE": (
+                            "camera"
+                        ),
+                        "VISIONLAB_CAMERA_INDEX": "2",
+                    },
+                )
+            )
+
+        self.assertIs(
+            selected_source,
+            frame_source,
+        )
+        iter_camera.assert_called_once_with(
+            2
+        )
+        resolve_video.assert_not_called()
+        iter_video.assert_not_called()
+
+    def test_invalid_camera_index_configuration_is_rejected(
+        self,
+    ) -> None:
+        invalid_indices = (
+            None,
+            "",
+            "-1",
+            "1.5",
+            "camera-zero",
+        )
+
+        for invalid_index in invalid_indices:
+            with self.subTest(
+                camera_index=invalid_index
+            ):
+                environment = {
+                    "VISIONLAB_INPUT_SOURCE": (
+                        "camera"
+                    ),
+                }
+
+                if invalid_index is not None:
+                    environment[
+                        "VISIONLAB_CAMERA_INDEX"
+                    ] = invalid_index
+
+                with patch(
+                    f"{RUNNER_MODULE}."
+                    "iter_camera_frames",
+                ) as iter_camera:
+                    with self.assertRaisesRegex(
+                        ControlledIlluminationPurePythonRunnerError,
+                        (
+                            "VISIONLAB_CAMERA_INDEX "
+                            "must be a non-negative "
+                            "integer"
+                        ),
+                    ):
+                        (
+                            pure_python_runner
+                            .create_frame_source(
+                                {},
+                                environment=environment,
+                            )
+                        )
+
+                iter_camera.assert_not_called()
+
+    def test_failed_camera_run_does_not_write_artifacts(
+        self,
+    ) -> None:
+        environment = {
+            "VISIONLAB_INPUT_SOURCE": "camera",
+            "VISIONLAB_CAMERA_INDEX": "0",
+        }
+        realtime_config = SimpleNamespace(
+            warmup_frames=30,
+        )
+
+        with (
+            patch(
+                f"{RUNNER_MODULE}."
+                "load_runner_context_from_environment",
+                return_value=self.context,
+            ),
+            patch(
+                f"{RUNNER_MODULE}."
+                "load_benchmark_config",
+                return_value={},
+            ),
+            patch(
+                f"{RUNNER_MODULE}."
+                "load_realtime_config",
+                return_value=realtime_config,
+            ),
+            patch(
+                f"{RUNNER_MODULE}."
+                "validate_shared_execution_counts",
+            ),
+            patch(
+                f"{RUNNER_MODULE}."
+                "validate_context_against_configuration",
+            ),
+            patch(
+                f"{RUNNER_MODULE}."
+                "select_algorithm_configuration",
+                return_value={},
+            ),
+            patch(
+                f"{RUNNER_MODULE}."
+                "create_frame_processor",
+                return_value=object(),
+            ),
+            patch(
+                f"{RUNNER_MODULE}."
+                "create_frame_source",
+                return_value=object(),
+            ),
+            patch(
+                f"{RUNNER_MODULE}."
+                "run_realtime_trial",
+                side_effect=RuntimeError(
+                    "Camera 0 could not be opened."
+                ),
+            ),
+            patch(
+                f"{RUNNER_MODULE}."
+                "write_completed_run_artifacts_atomic",
+            ) as write_artifacts,
+        ):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "Camera 0 could not be opened",
+            ):
+                execute_pure_python_run(
+                    environment,
+                    now_provider=lambda: STARTED_AT,
+                )
+
+        write_artifacts.assert_not_called()
 
 if __name__ == "__main__":
     unittest.main()

--- a/benchmarks/experiments/tests/test_controlled_illumination_pure_python_runner.py
+++ b/benchmarks/experiments/tests/test_controlled_illumination_pure_python_runner.py
@@ -488,7 +488,6 @@ class ControlledIlluminationPurePythonRunnerTests(
             patch(
                 f"{RUNNER_MODULE}."
                 "iter_camera_frames",
-                create=True,
                 return_value=frame_source,
             ) as iter_camera,
             patch(

--- a/benchmarks/realtime/realtime_pipeline.py
+++ b/benchmarks/realtime/realtime_pipeline.py
@@ -67,6 +67,55 @@ def iter_video_frames(
         capture.release()
 
 
+def iter_camera_frames(
+    camera_index: int,
+) -> Iterator[np.ndarray]:
+    if (
+        isinstance(camera_index, bool)
+        or not isinstance(camera_index, int)
+        or camera_index < 0
+    ):
+        raise ValueError(
+            "camera_index must be a "
+            "non-negative integer."
+        )
+
+    capture = cv2.VideoCapture(
+        camera_index
+    )
+
+    try:
+        if not capture.isOpened():
+            raise RuntimeError(
+                f"Camera {camera_index} "
+                "could not be opened."
+            )
+
+        while True:
+            frame_received, frame = (
+                capture.read()
+            )
+
+            if not frame_received:
+                raise RuntimeError(
+                    f"A frame could not be read "
+                    f"from camera {camera_index}."
+                )
+
+            if (
+                frame is None
+                or frame.size == 0
+            ):
+                raise RuntimeError(
+                    "An empty frame was read "
+                    f"from camera {camera_index}."
+                )
+
+            yield frame
+    finally:
+        capture.release()
+
+
 def validate_input_frame(
     frame: np.ndarray,
 ) -> None:

--- a/benchmarks/realtime/tests/test_realtime_pipeline.py
+++ b/benchmarks/realtime/tests/test_realtime_pipeline.py
@@ -4,6 +4,9 @@ from pathlib import Path
 from threading import Event
 
 import numpy as np
+from unittest.mock import Mock, patch
+
+from benchmarks.realtime import realtime_pipeline
 
 from benchmarks.realtime.realtime_config import (
     RealtimeConfig,
@@ -295,6 +298,199 @@ class RealtimePipelineTests(unittest.TestCase):
         ):
             next(frame_iterator)
 
+    def test_camera_open_failure_is_rejected(
+        self,
+    ) -> None:
+        capture = Mock()
+        capture.isOpened.return_value = False
+
+        with patch.object(
+            realtime_pipeline.cv2,
+            "VideoCapture",
+            return_value=capture,
+        ) as video_capture:
+            frame_iterator = (
+                realtime_pipeline.iter_camera_frames(
+                    0
+                )
+            )
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "Camera 0 could not be opened",
+            ):
+                next(frame_iterator)
+
+        video_capture.assert_called_once_with(0)
+        capture.release.assert_called_once_with()
+
+    def test_camera_frame_is_yielded_and_released(
+        self,
+    ) -> None:
+        expected_frame = self.create_frames(
+            1
+        )[0]
+
+        capture = Mock()
+        capture.isOpened.return_value = True
+        capture.read.return_value = (
+            True,
+            expected_frame,
+        )
+
+        with patch.object(
+            realtime_pipeline.cv2,
+            "VideoCapture",
+            return_value=capture,
+        ):
+            frame_iterator = (
+                realtime_pipeline.iter_camera_frames(
+                    0
+                )
+            )
+
+            actual_frame = next(
+                frame_iterator
+            )
+            frame_iterator.close()
+
+        self.assertIs(
+            actual_frame,
+            expected_frame,
+        )
+        capture.read.assert_called_once_with()
+        capture.release.assert_called_once_with()
+
+    def test_empty_camera_frame_is_rejected(
+        self,
+    ) -> None:
+        capture = Mock()
+        capture.isOpened.return_value = True
+        capture.read.return_value = (
+            True,
+            np.empty(
+                (0, 0, 3),
+                dtype=np.uint8,
+            ),
+        )
+
+        with patch.object(
+            realtime_pipeline.cv2,
+            "VideoCapture",
+            return_value=capture,
+        ):
+            frame_iterator = (
+                realtime_pipeline.iter_camera_frames(
+                    0
+                )
+            )
+
+            try:
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "empty frame",
+                ):
+                    next(frame_iterator)
+            finally:
+                frame_iterator.close()
+
+        capture.release.assert_called_once_with()
+
+    def test_camera_frame_read_failure_is_rejected(
+        self,
+    ) -> None:
+        capture = Mock()
+        capture.isOpened.return_value = True
+        capture.read.return_value = (
+            False,
+            None,
+        )
+
+        with patch.object(
+            realtime_pipeline.cv2,
+            "VideoCapture",
+            return_value=capture,
+        ):
+            frame_iterator = (
+                realtime_pipeline.iter_camera_frames(
+                    2
+                )
+            )
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                (
+                    "could not be read "
+                    "from camera 2"
+                ),
+            ):
+                next(frame_iterator)
+
+        capture.release.assert_called_once_with()
+
+    def test_negative_camera_index_is_rejected_before_open(
+        self,
+    ) -> None:
+        capture = Mock()
+        capture.isOpened.return_value = False
+
+        with patch.object(
+            realtime_pipeline.cv2,
+            "VideoCapture",
+            return_value=capture,
+        ) as video_capture:
+            frame_iterator = (
+                realtime_pipeline.iter_camera_frames(
+                    -1
+                )
+            )
+
+            with self.assertRaisesRegex(
+                ValueError,
+                (
+                    "camera_index must be a "
+                    "non-negative integer"
+                ),
+            ):
+                next(frame_iterator)
+
+        video_capture.assert_not_called()
+
+    def test_non_integer_camera_indices_are_rejected_before_open(
+        self,
+    ) -> None:
+        invalid_indices = (
+            True,
+            1.5,
+            "0",
+            None,
+        )
+
+        with patch.object(
+            realtime_pipeline.cv2,
+            "VideoCapture",
+        ) as video_capture:
+            for invalid_index in invalid_indices:
+                with self.subTest(
+                    camera_index=invalid_index
+                ):
+                    frame_iterator = (
+                        realtime_pipeline
+                        .iter_camera_frames(
+                            invalid_index
+                        )
+                    )
+
+                    with self.assertRaisesRegex(
+                        ValueError,
+                        (
+                            "camera_index must be a "
+                            "non-negative integer"
+                        ),
+                    ):
+                        next(frame_iterator)
+
+        video_capture.assert_not_called()
 
 if __name__ == "__main__":
     unittest.main()

--- a/benchmarks/realtime/tests/test_realtime_pipeline.py
+++ b/benchmarks/realtime/tests/test_realtime_pipeline.py
@@ -2,9 +2,9 @@ import time
 import unittest
 from pathlib import Path
 from threading import Event
+from unittest.mock import Mock, patch
 
 import numpy as np
-from unittest.mock import Mock, patch
 
 from benchmarks.realtime import realtime_pipeline
 


### PR DESCRIPTION
## Summary

Add configurable OpenCV live-camera input to the controlled-illumination Pure Python runner while preserving deterministic benchmark-video input as the backward-compatible default.

## Changes

- Add a reusable `iter_camera_frames()` source with camera-index validation.
- Detect camera-open, frame-read and empty-frame failures.
- Guarantee `VideoCapture` release on normal closure and failure paths.
- Select `video` or `camera` input through `VISIONLAB_INPUT_SOURCE`.
- Configure the camera device through `VISIONLAB_CAMERA_INDEX`.
- Integrate the selected frame source with the existing Pure Python real-time trial pipeline.
- Prevent completed-run artifacts from being written when camera initialization fails.
- Add hardware-independent tests using mocked OpenCV capture objects.
- Document video and live-camera runner configuration and experimental limitations.

## Validation

- Targeted real-time pipeline and Pure Python runner tests: 27 passed
- Controlled-illumination experiment tests: 235 passed
- Real-time tests: 51 passed
- `git diff --check`: passed

## Scope

This pull request adds camera input only to the controlled-illumination Pure Python runner. Camera control, calibration, Hybrid/Pure C++ integration, embedded deployment and official physical experiments remain out of scope.

Closes #44